### PR TITLE
8461 [WIP] shot metadata

### DIFF
--- a/bin/sg-otio
+++ b/bin/sg-otio
@@ -8,6 +8,7 @@
 
 import argparse
 import logging
+import os
 
 import opentimelineio as otio
 from shotgun_api3 import Shotgun
@@ -17,6 +18,7 @@ from sg_otio.utils import get_write_url, get_read_url
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("sg-otio")
+
 
 def run():
     """
@@ -74,6 +76,12 @@ def run():
         "--settings", "-s",
         required=False,
         help="The settings JSON file to use when writing the Cut. If not provided, the default settings are used."
+    )
+    write_parser.add_argument(
+        "--movie", "-m",
+        required=False,
+        help="An optional movie of the timeline so that it can be published as a Version and used to create Versions" \
+             "for each clip"
     )
 
     args = parser.parse_args()
@@ -140,7 +148,11 @@ def write_to_sg(args):
     )
     if args.settings:
         SGSettings.from_file(args.settings)
-    otio.adapters.write_to_file(timeline, url, adapter_name="ShotGrid")
+    # Add the movie as metadata
+    if args.movie:
+        if not os.path.isfile(args.movie):
+            raise ValueError("%s does not exist" % args.movie)
+    otio.adapters.write_to_file(timeline, url, adapter_name="ShotGrid", input_media=args.movie)
     logger.info("File %s successfully written to %s" % (args.file, url))
 
 

--- a/bin/sg-otio
+++ b/bin/sg-otio
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# Copyright 2022 GPL Solutions, LLC.  All rights reserved.
+#
+# Use of this software is subject to the terms of the GPL Solutions license
+# agreement provided at the time of installation or download, or which otherwise
+# accompanies this software in either electronic or hard copy form.
+#
+
+import argparse
+import logging
+
+import opentimelineio as otio
+from shotgun_api3 import Shotgun
+
+from sg_otio.sg_settings import SGSettings
+from sg_otio.utils import get_write_url, get_read_url
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("sg-otio")
+
+def run():
+    """
+    Parse command line arguments and read Cuts from SG to a file, or write files to SG as Cuts.
+    """
+    parser = argparse.ArgumentParser(description="Read Cuts from SG to a file, or write files to SG as Cuts.")
+    subparser = parser.add_subparsers(dest="command")
+    # Read sub parser
+    read_parser = subparser.add_parser(
+        "read",
+        help="Read a Cut from SG and write it to a file, or to the std output in OTIO format."
+    )
+    # Write sub parser
+    write_parser = subparser.add_parser(
+        "write",
+        help="Write a Timeline or a video track to SG as a Cut."
+    )
+    # Common arguments for read and write.
+    # We need to add them to the subparsers and not the main parser so that
+    # the first positional argument is "read" or "write".
+    add_common_args(read_parser)
+    add_common_args(write_parser)
+
+    # Read parameters
+    read_parser.add_argument(
+        "--cut-id", "-i",
+        required=True,
+        help="The ID of the SG Cut to read."
+    )
+    read_parser.add_argument(
+        "--file", "-f",
+        required=False,
+        help="An optional file to write the Cut to when reading it."
+             "If not provided, the output is printed to stdout in OTIO format."
+    )
+    # Write parameters
+    write_parser.add_argument(
+        "--file", "-f",
+        required=True,
+        help="The file to read the Timeline from (can be OTIO, EDL, etc)."
+    )
+    write_parser.add_argument(
+        "--entity-type", "-e",
+        required=True,
+        help="The SG Entity type to link the Cut to. It can be a Project, a Cut, or any Entity that can be linked to "
+             "a Cut, e.g. a Sequence, a Reel."
+    )
+    write_parser.add_argument(
+        "--entity-id", "-i",
+        required=True,
+        type=int,
+        help="The SG Entity id to link the Cut to."
+    )
+    write_parser.add_argument(
+        "--settings", "-s",
+        required=False,
+        help="The settings JSON file to use when writing the Cut. If not provided, the default settings are used."
+    )
+
+    args = parser.parse_args()
+
+    # Check that we can log in to SG
+    if not (args.login and args.password):
+        if not (args.script and args.api_key):
+            if not args.session_token:
+                raise ValueError(
+                    "You must provide either a login, password, script name and API key or a session token."
+                )
+
+    if args.command == "read":
+        read_from_sg(args)
+    elif args.command == "write":
+        write_to_sg(args)
+
+
+def read_from_sg(args):
+    """
+    Reads information from a Cut in ShotGrid and print it
+    to stdout, or write it to a file.
+
+    If printed to stdout, the output is in OTIO format.
+    If written to a file, the output depends on the extension of the file
+    or the adapter chosen.
+
+    The retrieved SG entities are stored in the items metadata.
+
+    :param args: The command line arguments.
+    """
+    url = get_read_url(
+        sg_site_url=args.sg_site_url,
+        cut_id=args.cut_id,
+        session_token=_get_session_token(args)
+    )
+    timeline = otio.adapters.read_from_file(
+        url,
+        adapter_name="ShotGrid",
+    )
+    if not args.file:
+        logger.info(otio.adapters.write_to_string(timeline))
+    else:
+        otio.adapters.write_to_file(timeline, args.file, adapter_name=args.adapter)
+
+
+def write_to_sg(args):
+    """
+    Write an input file to SG as a Cut.
+
+    The input file can be any format supported by OTIO.
+    If no adapter is provided, the default adapter for the file extension is used.
+
+    :param args: The command line arguments.
+    """
+    url = get_write_url(
+        sg_site_url=args.sg_site_url,
+        entity_type=args.entity_type,
+        entity_id=args.entity_id,
+        session_token=_get_session_token(args)
+    )
+    timeline = otio.adapters.read_from_file(
+        args.file, adapter_name=args.adapter
+    )
+    if args.settings:
+        SGSettings.from_file(args.settings)
+    otio.adapters.write_to_file(timeline, url, adapter_name="ShotGrid")
+    logger.info("File %s successfully written to %s" % (args.file, url))
+
+
+def add_common_args(parser):
+    """
+    Add common arguments for reading and writing from/to SG.
+
+    :param parser: An instance of :class:`argparse.ArgumentParser`.
+    """
+    # Common arguments to read and write
+    parser.add_argument(
+        "--sg-site-url", "-u",
+        required=True,
+        help="The SG URL to read the Cut from."
+    )
+    # Read login parameters
+    # Option 1: login + password
+    parser.add_argument(
+        "--login", "-l",
+        required=False,
+        help="The SG login to use to login."
+    )
+    parser.add_argument(
+        "--password", "-p",
+        required=False,
+        help="The SG password to use to login."
+    )
+    # Option 2: script name and API key
+    parser.add_argument(
+        "--script-name", "-sn",
+        required=False,
+        help="The SG script name to use to login."
+    )
+    parser.add_argument(
+        "--api-key", "-k",
+        required=False,
+        help="The SG API key to use to login."
+    )
+    # Option 3: session token
+    parser.add_argument(
+        "--session-token", "-t",
+        required=False,
+        help="The SG session token to use to login."
+    )
+    parser.add_argument(
+        "--adapter", "-a",
+        required=False,
+        help="The adapter to use to read or write the file. If not provided, the default adapter"
+             "given the extension is used."
+    )
+
+
+def _get_session_token(args):
+    """
+    Get the session token from the arguments.
+
+    :param args: The command line arguments.
+    """
+    if args.session_token:
+        return args.session_token
+    if args.login and args.password:
+        sg = Shotgun(args.sg_site_url, login=args.login, password=args.password)
+    elif args.script_name and args.api_key:
+        sg = Shotgun(args.sg_site_url, script_name=args.script_name, api_key=args.api_key)
+    return sg.get_session_token()
+
+
+if __name__ == "__main__":
+    run()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/GPLgithub/sg-otio.git",
     packages=setuptools.find_packages(),
+    scripts=["bin/sg-otio"],
     entry_points={
         "opentimelineio.plugins": "sg_otio = sg_otio"
     },

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -10,7 +10,7 @@ from six.moves.urllib import parse
 import opentimelineio as otio
 import shotgun_api3
 
-from sg_otio.constants import _CUT_ITEM_FIELDS, _CUT_FIELDS, _SHOT_FIELDS
+from sg_otio.constants import _CUT_ITEM_FIELDS, _CUT_FIELDS  # , _SHOT_FIELDS
 from sg_otio.sg_cut_track_writer import SGCutTrackWriter
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -91,18 +91,20 @@ def read_from_file(filepath):
         _CUT_ITEM_FIELDS,
         order=[{"field_name": "cut_order", "direction": "asc"}]
     )
-    # We could avoid an extra query by adding shot.Shot.XXX to the _CUT_FIELDS using _SHOT_FIELDS, but it would
-    # require some cleaning up of the cut_item afterwards.
-    shot_ids = [cut_item["shot"]["id"] for cut_item in cut_items if cut_item.get("shot", {}).get("id")]
-    shots = sg.find(
-        "Shot",
-        [["id", "in", shot_ids]],
-        _SHOT_FIELDS
-    )
-    shots_by_id = {shot["id"]: shot for shot in shots}
+#    # We could avoid an extra query by adding shot.Shot.XXX to the _CUT_FIELDS using _SHOT_FIELDS, but it would
+#    # require some cleaning up of the cut_item afterwards.
+#    shot_ids = [cut_item["shot"]["id"] for cut_item in cut_items if cut_item.get("shot", {}).get("id")]
+#    shots = sg.find(
+#        "Shot",
+#        [["id", "in", shot_ids]],
+#        _SHOT_FIELDS
+#    )
+#    shots_by_id = {shot["id"]: shot for shot in shots}
     for cut_item in cut_items:
+        # if cut_item["shot"]:
+        #     cut_item["shot"] = shots_by_id[cut_item["shot"]["id"]]
         if cut_item["shot"]:
-            cut_item["shot"] = shots_by_id[cut_item["shot"]["id"]]
+            cut_item["shot"]["code"] = cut_item["shot.Shot.code"]
         clip = otio.schema.Clip()
         # Not sure if there is a better way to allow writing to EDL and getting the right
         # Reel name without having this dependency to the CMX adapter.

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -162,7 +162,7 @@ def read_from_file(filepath):
     return timeline
 
 
-def write_to_file(input_otio, filepath):
+def write_to_file(input_otio, filepath, input_media=None):
     """
     Write the given timeline to SG.
 
@@ -175,8 +175,12 @@ def write_to_file(input_otio, filepath):
     - An arbitrary Entity type, e.g. a Sequence, a new Cut will be created, linked
       to the Entity.
 
+    If an input_media is provided, it will be used to create a Version and a Published File
+    for the cut, and possibly Versions for individual clips.
+
     :param input_otio: An :class:`otio.schema.Timeline` instance.
     :param str filepath: A query URL.
+    :param str input_media: A path to a media file representing the video track, if any.
     :raises ValueError: For unsupported SG Entity types.
     """
     if not isinstance(input_otio, otio.schema.Timeline) and not isinstance(input_otio, otio.schema.Track):
@@ -202,6 +206,7 @@ def write_to_file(input_otio, filepath):
         entity_type,
         entity_id,
         video_track,
-        description="Generated from sg-otio"
+        description="Generated from sg-otio",
+        input_media=input_media
     )
     return

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -10,7 +10,7 @@ from six.moves.urllib import parse
 import opentimelineio as otio
 import shotgun_api3
 
-from sg_otio.constants import _CUT_ITEM_FIELDS, _CUT_FIELDS
+from sg_otio.constants import _CUT_ITEM_FIELDS, _CUT_FIELDS, _SHOT_FIELDS
 from sg_otio.sg_cut_track_writer import SGCutTrackWriter
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -91,7 +91,18 @@ def read_from_file(filepath):
         _CUT_ITEM_FIELDS,
         order=[{"field_name": "cut_order", "direction": "asc"}]
     )
+    # We could avoid an extra query by adding shot.Shot.XXX to the _CUT_FIELDS using _SHOT_FIELDS, but it would
+    # require some cleaning up of the cut_item afterwards.
+    shot_ids = [cut_item["shot"]["id"] for cut_item in cut_items if cut_item.get("shot", {}).get("id")]
+    shots = sg.find(
+        "Shot",
+        [["id", "in", shot_ids]],
+        _SHOT_FIELDS
+    )
+    shots_by_id = {shot["id"]: shot for shot in shots}
     for cut_item in cut_items:
+        if cut_item["shot"]:
+            cut_item["shot"] = shots_by_id[cut_item["shot"]["id"]]
         clip = otio.schema.Clip()
         # Not sure if there is a better way to allow writing to EDL and getting the right
         # Reel name without having this dependency to the CMX adapter.

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -68,6 +68,10 @@ def read_from_file(filepath):
     )
     if not cut:
         raise ValueError("No Cut found with ID {}".format(cut_id))
+    if cut["created_at"]:
+        cut["created_at"] = str(cut["created_at"])
+    if cut["updated_at"]:
+        cut["updated_at"] = str(cut["updated_at"])
     # TODO: check if we should just return a track or a timeline?
     timeline = otio.schema.Timeline(name=cut["code"])
     track = otio.schema.Track(name=cut["code"])
@@ -145,9 +149,9 @@ def read_from_file(filepath):
             clip.name = cut_item["version"]["name"]
         else:
             clip.name = cut_item["code"]
-        clip.source_range = otio.opentime.TimeRange(
-            start_time=otio.opentime.from_timecode(cut_item["timecode_cut_item_in_text"], cut["fps"]),
-            duration=otio.opentime.from_timecode(cut_item["timecode_cut_item_out_text"], cut["fps"])
+        clip.source_range = otio.opentime.range_from_start_end_time(
+            otio.opentime.from_timecode(cut_item["timecode_cut_item_in_text"], cut["fps"]),
+            otio.opentime.from_timecode(cut_item["timecode_cut_item_out_text"], cut["fps"])
         )
         # TODO: Add media reference for Version. This would require some logic to get them either
         #       from the uploaded media, but the AWS links expire after a while, or from the

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -100,9 +100,40 @@ def read_from_file(filepath):
 #        _SHOT_FIELDS
 #    )
 #    shots_by_id = {shot["id"]: shot for shot in shots}
-    for cut_item in cut_items:
-        # if cut_item["shot"]:
-        #     cut_item["shot"] = shots_by_id[cut_item["shot"]["id"]]
+    # Check for gaps and overlaps
+    for i, cut_item in enumerate(cut_items):
+        if i > 0:
+            prev_cut_item = cut_items[i - 1]
+            if prev_cut_item["edit_out"]:
+                prev_edit_out = otio.opentime.from_frames(prev_cut_item["edit_out"], cut["fps"])
+            elif prev_cut_item["timecode_edit_out_text"]:
+                prev_edit_out = otio.opentime.from_timecode(prev_cut_item["timecode_edit_out_text"], cut["fps"])
+            else:
+                raise ValueError("No edit_out found for cut_item %s" % prev_cut_item)
+            # We start frame numbering at one
+            # since timecode out is exclusive we just use it to not do 1 + value -1
+            if cut_item["edit_in"]:
+                edit_in = otio.opentime.from_frames(cut_item["edit_in"] - 1, cut["fps"])
+            elif cut_item["timecode_edit_in_text"]:
+                edit_in = otio.opentime.from_timecode(cut_item["timecode_edit_in_text"], cut["fps"])
+            else:
+                raise ValueError("No edit_in found for cut_item %s" % cut_item)
+            if prev_edit_out > edit_in:
+                raise ValueError("Overlapping cut items detected: %s ends at %s but %s starts at %s" % (
+                    prev_cut_item["code"], prev_edit_out.to_timecode(), cut_item["code"], edit_in.to_timecode()
+                ))
+            # Check if there's a gap between the two clips and add a gap if there is.
+            if edit_in > prev_edit_out:
+                logger.debug("Adding gap between cut items %s (ends at %s) and %s (starts at %s)" % (
+                    prev_cut_item["code"], prev_edit_out.to_timecode(), cut_item["code"], edit_in.to_timecode()
+                ))
+                gap = otio.schema.Gap()
+                gap.source_range = otio.opentime.TimeRange(
+                    start_time=otio.opentime.RationalTime(0, cut["fps"]),
+                    duration=edit_in - prev_edit_out
+                )
+                track.append(gap)
+        # Check if there's an overlap of clips and flag it.
         if cut_item["shot"]:
             cut_item["shot"]["code"] = cut_item["shot.Shot.code"]
         clip = otio.schema.Clip()
@@ -114,14 +145,6 @@ def read_from_file(filepath):
             clip.name = cut_item["version"]["name"]
         else:
             clip.name = cut_item["code"]
-#        if cut_item["shot"]:
-#            clip.metadata["sg"]["shot"] = cut_item.pop("shot")
-#        if cut_item["version"]:
-#            clip.name = cut_item["version"]["name"]
-#            clip.metadata["sg"]["version"] = cut_item.pop("version")
-#        else:
-#            clip.name = cut_item["code"]
-#        clip.metadata["sg"]["cut_item"] = cut_item
         clip.source_range = otio.opentime.TimeRange(
             start_time=otio.opentime.from_timecode(cut_item["timecode_cut_item_in_text"], cut["fps"]),
             duration=otio.opentime.from_timecode(cut_item["timecode_cut_item_out_text"], cut["fps"])

--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -50,6 +50,7 @@ _CUT_ITEM_FIELDS = [
     "cut_item_in",
     "cut_item_out",
     "shot",
+    "shot.Shot.code",
     # "cut_duration",  # Does not seem to exist?
     "cut_item_duration",
     "cut.Cut.fps",

--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -49,6 +49,8 @@ _CUT_ITEM_FIELDS = [
     "cut_order",
     "cut_item_in",
     "cut_item_out",
+    "edit_in",
+    "edit_out",
     "shot",
     "shot.Shot.code",
     # "cut_duration",  # Does not seem to exist?

--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -50,7 +50,6 @@ _CUT_ITEM_FIELDS = [
     "cut_item_in",
     "cut_item_out",
     "shot",
-    "shot.Shot.code",
     # "cut_duration",  # Does not seem to exist?
     "cut_item_duration",
     "cut.Cut.fps",

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -518,7 +518,9 @@ class CutClip(otio.schema.Clip):
         The reel name is only used if `_use_clip_names_for_shot_names` is True.
         If a `_clip_name_shot_regexp` is set, it will be used to extract the shot name from the reel name.
         """
-        if self.metadata.get("sg", {}).get("shot", {}).get("code"):
+        sg_metadata = self.metadata.get("sg", {}) or {}
+        shot_metadata = sg_metadata.get("shot", {}) or {}
+        if shot_metadata.get("code"):
             self.shot_name = self.metadata["sg"]["shot"]["code"]
             return
         if self.markers:

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -518,8 +518,8 @@ class CutClip(otio.schema.Clip):
         The reel name is only used if `_use_clip_names_for_shot_names` is True.
         If a `_clip_name_shot_regexp` is set, it will be used to extract the shot name from the reel name.
         """
-        if self.metadata.get("sg", {}).get("shot.Shot.code"):
-            self.shot_name = self.metadata["sg"]["shot.Shot.code"]
+        if self.metadata.get("sg", {}).get("shot", {}).get("code"):
+            self.shot_name = self.metadata["sg"]["shot"]["code"]
             return
         if self.markers:
             self.shot_name = self.markers[0].name.split()[0]

--- a/sg_otio/cut_track.py
+++ b/sg_otio/cut_track.py
@@ -171,24 +171,18 @@ class CutTrack(otio.schema.Track):
         """
         Returns the :class:`ClipGroup` instances of the track.
 
-        ..note:: some clips might not have information to be able to link them to a shot,
-        in which case the :class:`ClipGroup` does exist, but its name is ``None``.
-
         :returns: A list of :class:`ClipGroup` instances.
         """
-        return list(self._shots_by_name.values())
+        return [v for k, v in self._shots_by_name.items() if k is not None]
 
     @property
     def shot_names(self):
         """
         Returns the names of the shots of the track.
 
-        There can be a shot named ``None`` if some clips don't have information
-        to be able to link them to a shot.
-
         :returns: A list of shot names.
         """
-        return list(self._shots_by_name.keys())
+        return [k for k in self._shots_by_name.keys() if k is not None]
 
     @property
     def shots_by_name(self):

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -15,7 +15,7 @@ from .constants import _EFFECTS_FIELD, _RETIME_FIELD
 from .constants import _ENTITY_CUT_ORDER_FIELD, _ABSOLUTE_CUT_ORDER_FIELD
 from .cut_clip import CutClip
 from .cut_track import CutTrack
-from .sg_settings import SGShotFieldsConfig
+from .sg_settings import SGShotFieldsConfig, SGSettings
 
 try:
     # For Python 3.4 or later
@@ -48,6 +48,8 @@ class SGCutTrackWriter(object):
         """
         logger.setLevel(log_level)
         self._sg = sg
+        # Local storages by name.
+        self._local_storages = {}
 
     @property
     def cut_item_schema(self):
@@ -60,7 +62,7 @@ class SGCutTrackWriter(object):
             self._cut_item_schema[self._sg.base_url] = self._sg.schema_field_read("CutItem")
         return self._cut_item_schema[self._sg.base_url]
 
-    def write_to(self, entity_type, entity_id, video_track, sg_user=None, description=""):
+    def write_to(self, entity_type, entity_id, video_track, input_media=None, sg_user=None, description=""):
         """
         Gather information about a Cut, its Cut Items and their linked Shots and create
         or update Entities accordingly in SG.
@@ -73,6 +75,7 @@ class SGCutTrackWriter(object):
         :param str entity_type: A SG Entity type.
         :param int entity_id: A SG Entity ID.
         :param video_track: An OTIO Video Track or a CutTrack.
+        :param str input_media: An optional input media. If provided, a Version will be created for the Cut.
         :param sg_user: An optional SG User which will be registered when creating/updating Entities.
         :param description: An optional description for the Cut.
         """
@@ -104,6 +107,8 @@ class SGCutTrackWriter(object):
             sg_user
         )
         self._write_cut_items(video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_shots, sg_user)
+        if input_media:
+            self._create_input_media_version(input_media, cut_track.name, sg_project, sg_linked_entity, sg_user)
 
     def _write_cut(self, video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_user=None, description=""):
         """
@@ -490,49 +495,56 @@ class SGCutTrackWriter(object):
             raise ValueError("Unable to retrieve a Project from %s %s")
         return sg_project, sg_cut, sg_linked_entity
 
-    @staticmethod
-    def _retrieve_local_storage(sg, local_storage_name):
+    def _retrieve_local_storage(self):
         """
         Retrieve a Local Storage path given its name.
 
-        :param sg: A ShotGrid API session instance.
-        :param str local_storage_name: The name of the Local Storage.
         :raises ValueError: If LocalStorages can't be retrieved.
         :raises RuntimeError: If the platform is not supported.
         :returns: A SG Local Storage entity.
         """
-        platform = sys.platform
-        if platform == "win32":
-            path_field = "windows_path"
-        elif platform == "darwin":
-            path_field = "mac_path"
-        elif platform.startswith("linux"):
-            path_field = "linux_path"
-        else:
-            raise RuntimeError("Platform %s is not supported" % platform)
+        local_storage_name = SGSettings().local_storage_name
+        if not self._local_storages.get(local_storage_name):
+            platform = sys.platform
+            if platform == "win32":
+                path_field = "windows_path"
+            elif platform == "darwin":
+                path_field = "mac_path"
+            elif platform.startswith("linux"):
+                path_field = "linux_path"
+            else:
+                raise RuntimeError("Platform %s is not supported" % platform)
 
-        local_storage = sg.find_one(
-            "LocalStorage",
-            [["code", "is", local_storage_name]],
-            [path_field]
-        )
-        if not local_storage:
-            raise ValueError(
-                "Unable to retrieve a Local Storage with the name %s" % local_storage_name
+            local_storage = self._sg.find_one(
+                "LocalStorage",
+                [["code", "is", local_storage_name]],
+                [path_field]
             )
-        # Update the dictionary so that there is a "path" key no matter what the platform is.
-        local_storage["path"] = local_storage[path_field]
-        return local_storage
+            if not local_storage:
+                raise ValueError(
+                    "Unable to retrieve a Local Storage with the name %s" % local_storage_name
+                )
+            # Update the dictionary so that there is a "path" key no matter what the platform is.
+            local_storage["path"] = local_storage[path_field]
+            self._local_storages[local_storage_name] = local_storage
+        return self._local_storages[local_storage_name]
 
-    def _create_input_media_version(self):
+    def _create_input_media_version(self, input_media, track_name, sg_project, sg_linked_entity, sg_user=None):
         """
         Creates a Version and a Published File for an input media
         representing the whole Timeline.
 
+        :param input_media: The path to the input media.
+        :param str track_name: The track name.
+        :param sg_project: A SG Project.
+        :param sg_linked_entity: A SG Entity or ``None``.
+        :param sg_user: A SG User or ``None``.
         :returns: A tuple of (SG Version, SG PublishedFile).
         """
+        linked_entity = sg_linked_entity or sg_project
+        local_storage = self._retrieve_local_storage()
         # Create the Version
-        version_name, file_extension = os.path.splitext(os.path.basename(self._input_media))
+        version_name, file_extension = os.path.splitext(os.path.basename(input_media))
         # Get the extension without '.' to use as a published_file_type
         file_extension = file_extension[1:]
         published_file_type = self._sg.find_one(
@@ -546,22 +558,22 @@ class SGCutTrackWriter(object):
                 {"code": file_extension}
             )
         version_payload = {
-            "project": self._project,
+            "project": sg_project,
             "code": version_name,
-            "entity": self._linked_entity,
-            "description": "Base media layer imported with Cut: %s" % self._track.name,
+            "entity": linked_entity,
+            "description": "Base media layer imported with Cut: %s" % track_name,
             "sg_first_frame": 1,
             "sg_movie_has_slate": False,
-            "sg_path_to_movie": self._input_media,
+            "sg_path_to_movie": input_media,
         }
-        if self._user:
-            version_payload["created_by"] = self._user
-            version_payload["updated_by"] = self._user
+        if sg_user:
+            version_payload["created_by"] = sg_user
+            version_payload["updated_by"] = sg_user
         version = self._sg.create("Version", version_payload)
         # Create the Published File
         # Check if we can publish it with a local file path instead of a URL
-        if self._local_storage and self._input_media.startswith(self._local_storage["path"]):
-            relative_path = self._input_media[len(self._local_storage["path"]):]
+        if local_storage and input_media.startswith(local_storage["path"]):
+            relative_path = input_media[len(local_storage["path"]):]
             # Get rid of double slashes and replace backslashes by forward slashes.
             # SG doesn't seem to accept backslashes when creating
             # PublishedFiles with relative paths to local storage
@@ -569,33 +581,33 @@ class SGCutTrackWriter(object):
             relative_path = relative_path.replace("\\", "/")
             publish_path = {
                 "relative_path": relative_path,
-                "local_storage": self._local_storage
+                "local_storage": local_storage
             }
         else:
             publish_path = {
-                "url": pathlib.Path(os.path.abspath(self._input_media)).as_uri(),
+                "url": pathlib.Path(os.path.abspath(input_media)).as_uri(),
                 "name": version_name,
             }
         published_file_payload = {
             "code": version_name,
-            "project": self._project,
-            "entity": self._linked_entity,
+            "project": sg_project,
+            "entity": linked_entity,
             "path": publish_path,
             "published_file_type": published_file_type,
             "version_number": 1,
             "version": version
         }
-        if self._user:
-            published_file_payload["created_by"] = self._user
-            published_file_payload["updated_by"] = self._user
+        if sg_user:
+            published_file_payload["created_by"] = sg_user
+            published_file_payload["updated_by"] = sg_user
         published_file = self._sg.create("PublishedFile", published_file_payload)
 
         # Upload media to the version.
-        logger.info("Uploading movie...")
+        logger.info("Uploading movie %s..." % os.path.basename(input_media))
         self._sg.upload(
             "Version",
             version["id"],
-            self._input_media,
+            input_media,
             "sg_uploaded_movie"
         )
         return version, published_file

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -281,9 +281,12 @@ class SGCutTrackWriter(object):
         if batch_data:
             res = self._sg.batch(batch_data)
             # Update the clips SG metadata
-            for i, sg_cut_item in enumerate(res):
-                cut_item_clips[i].metadata["sg"] = sg_cut_item
-                logger.info("Updating %s SG metadata with %s" % (cut_item_clips[i], sg_cut_item))
+            for i, (sg_cut_item, new_sg_cut_item) in enumerate(zip(sg_cut_items_data, res)):
+                # The batch response does not provide all the information
+                # we had for the Shot. Add it back.
+                new_sg_cut_item["shot"] = sg_cut_item["shot"]
+                cut_item_clips[i].metadata["sg"] = new_sg_cut_item
+                logger.info("Updating %s SG metadata with %s" % (cut_item_clips[i], new_sg_cut_item))
 
     @staticmethod
     def _retrieve_local_storage(sg, local_storage_name):

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -11,12 +11,10 @@ import sys
 import opentimelineio as otio
 from opentimelineio.opentime import RationalTime
 
-# Relative imports don't work with the way OTIO loads adapters.
-from .constants import _ENTITY_CUT_ORDER_FIELD, _ABSOLUTE_CUT_ORDER_FIELD
 from .constants import _EFFECTS_FIELD, _RETIME_FIELD
-# from .sg_settings import SGShotFieldsConfig
-from .cut_track import CutTrack
+from .constants import _ENTITY_CUT_ORDER_FIELD, _ABSOLUTE_CUT_ORDER_FIELD
 from .cut_clip import CutClip
+from .cut_track import CutTrack
 from .sg_settings import SGShotFieldsConfig
 
 try:
@@ -33,11 +31,13 @@ logger = logging.getLogger(__name__)
 class SGCutTrackWriter(object):
     """
     A class to save a :class:`otio.schema.Track` of kind ``otio.schema.TrackKind.Video``
-    in Shotgrid.
-    """
+    in ShotGrid.
 
-    # The CutItem schema in ShotGrid. Make it a class variable to get it only once.
-    _cut_item_schema = None
+    It gathers information about the track and its clips and creates or updates the
+    corresponding ShotGrid Entities.
+    """
+    # The CutItem schema in ShotGrid, per ShotGrid site. Make it a class variable to get it only once.
+    _cut_item_schema = {}
 
     def __init__(self, sg, log_level=logging.INFO):
         """
@@ -48,12 +48,125 @@ class SGCutTrackWriter(object):
         """
         logger.setLevel(log_level)
         self._sg = sg
-        # FIXME: if another SG site is later used the schema will not be updated.
-        if not self._cut_item_schema:
-            self._cut_item_schema = self._sg.schema_field_read("CutItem")
 
-    def get_sg_cut_payload(self, cut_track, sg_user=None, description=""):
+    @property
+    def cut_item_schema(self):
         """
+        Return the Cut Item schema for the current SG site.
+
+        :returns: The Cut Item Schema.
+        """
+        if not self._cut_item_schema.get(self._sg.base_url):
+            self._cut_item_schema[self._sg.base_url] = self._sg.schema_field_read("CutItem")
+        return self._cut_item_schema[self._sg.base_url]
+
+    def write_to(self, entity_type, entity_id, video_track, sg_user=None, description=""):
+        """
+        Gather information about a Cut, its Cut Items and their linked Shots and create
+        or update Entities accordingly in SG.
+
+        When writing to SG, The Entity provided (type and ID) can be:
+        - The Cut itself
+        - The Project
+        - Any Entity to link the Cut against (e.g. Sequence, Reel...)
+
+        :param str entity_type: A SG Entity type.
+        :param int entity_id: A SG Entity ID.
+        :param video_track: An OTIO Video Track or a CutTrack.
+        :param sg_user: An optional SG User which will be registered when creating/updating Entities.
+        :param description: An optional description for the Cut.
+        """
+        cut_track = video_track
+        sg_track_data = video_track.metadata.get("sg")
+        if sg_track_data and sg_track_data["type"] != "Cut":
+            raise ValueError(
+                "Invalid {} SG data for a {}".format(sg_track_data["type"], "Cut")
+            )
+        # Convert to a CutTrack if one was not provided.
+        if not isinstance(cut_track, CutTrack):
+            # We need to give the track a parent so time transforms from the Clip
+            # to the track are correctly evaluated.
+            stack = otio.schema.Stack()
+            cut_track = CutTrack.from_track(video_track)
+            stack.append(cut_track)
+
+        sg_project, sg_cut, sg_linked_entity = self._get_cut_entities(
+            entity_type, entity_id
+        )
+        sg_cut = self._write_cut(
+            video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_user, description
+        )
+
+        sg_shots = self._write_shots(
+            cut_track,
+            sg_project,
+            sg_linked_entity,
+            sg_user
+        )
+        self._write_cut_items(video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_shots, sg_user)
+
+    def _write_cut(self, video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_user=None, description=""):
+        """
+        Gather information about a SG Cut given a video track, and create or update
+        the corresponding Cut in SG.
+
+        Add metadata to the OTIO video Track about the SG Cut.
+
+        :param video_track: An OTIO Video Track.
+        :param cut_track: An instance of :class:`CutTrack`.
+        :param sg_project: The SG Project to write the Cut to.
+        :param sg_cut: If provided, the SG Cut to update.
+        :param sg_linked_entity: If provided, the Entity the Cut will be linked to.
+        :param sg_user: An optional user to provide when creating/updating Entities in SG.
+        :param str description: An optional description for the Cut.
+        :returns: The SG Cut entity created.
+        """
+        sg_cut_data = self._get_sg_cut_payload(cut_track, sg_user, description)
+        if sg_cut:
+            # Update existing Cut
+            logger.info("Cut update payload %s" % sg_cut_data)
+            sg_cut = self._sg.update(
+                sg_cut["type"],
+                sg_cut["id"],
+                sg_cut_data,
+            )
+            video_track.metadata["sg"] = sg_cut
+        else:
+            revision_number = 1
+            previous_cut = self._sg.find_one(
+                "Cut",
+                [
+                    ["code", "is", cut_track.name],
+                    ["entity", "is", sg_linked_entity or sg_project],
+                ],
+                ["revision_number"],
+                order=[{"field_name": "revision_number", "direction": "desc"}]
+            )
+            if previous_cut:
+                revision_number = (previous_cut.get("revision_number") or 0) + 1
+            # Create a new Cut
+            sg_cut_data["project"] = sg_project
+            sg_cut_data["entity"] = sg_linked_entity or sg_project
+            sg_cut_data["revision_number"] = revision_number
+            logger.info("Cut create payload %s" % sg_cut_data)
+
+            sg_cut = self._sg.create(
+                "Cut",
+                sg_cut_data,
+            )
+            # Update the original track with the result
+            logger.info("Updating %s SG metadata with %s" % (video_track.name, sg_cut))
+            video_track.metadata["sg"] = sg_cut
+        return sg_cut
+
+    def _get_sg_cut_payload(self, cut_track, sg_user=None, description=""):
+        """
+        Gather information about a SG Cut given a CutTrack.
+
+        :param cut_track: An instance of :class:`CutTrack`.
+        :param sg_user: An optional user to provide when creating/updating Entities in SG.
+        :param str description: An optional description for the Cut.
+        :returns: A dictionary with the SG Cut payload.
         """
         # If the track starts at 00:00:00:00, for some reason it does not have a source range.
         if cut_track.source_range:
@@ -75,11 +188,97 @@ class SGCutTrackWriter(object):
             cut_payload["updated_by"] = sg_user
         if description:
             cut_payload["description"] = description
-#        if input_media_version:
-#            cut_payload["version"] = input_media_version
+        # if input_media_version:
+        #    cut_payload["version"] = input_media_version
         return cut_payload
 
-    def get_sg_cut_item_payload(self, cut_clip, sg_user=None, sg_shot=None):
+    def _write_cut_items(self, video_track, cut_track, sg_project, sg_cut, sg_linked_entity, sg_shots, sg_user):
+        """
+        Gather information about the Cut Items given a CutTrack, and create or update the Cut Items in SG
+        accordingly.
+
+        Add metadata to the OTIO Clips in the Track about the SG Cut Items.
+
+        :param video_track: An OTIO Video Track.
+        :param cut_track: An instance of :class:`CutTrack`.
+        :param sg_project: The SG Project to write the Cut to.
+        :param sg_cut: If provided, the SG Cut to update.
+        :param sg_linked_entity: If provided, the Entity the Cut will be linked to.
+        :param sg_shots: A list of SG Shots.
+        :param sg_user: An optional user to provide when creating/updating Entities in SG.
+        :returns: The SG Cut Items.
+        """
+        shots_by_name = {x["code"]: x for x in sg_shots}
+        shots_by_id = {x["id"]: x for x in sg_shots}
+        sg_cut_items_data = []
+        cut_item_clips = []
+
+        # Loop over clips from the cut_track
+        # Keep references to original clips
+        video_clips = list(video_track.each_clip())
+        for i, clip in enumerate(cut_track.each_clip()):
+            if not isinstance(clip, CutClip):
+                continue
+            # Get the SG Shot for this clip
+            sg_shot = shots_by_name.get(clip.shot_name)
+            sg_data = self.get_sg_cut_item_payload(clip, sg_shot=sg_shot, sg_user=sg_user)
+            sg_cut_items_data.append(sg_data)
+            # Make sure we keep a reference to the original clip to be able to set
+            # SG metadata.
+            cut_item_clips.append(video_clips[i])
+        batch_data = []
+        linked_entity = sg_linked_entity or sg_project
+        for item_index, sg_cut_item_data in enumerate(sg_cut_items_data):
+            sg_cut_item_data["cut"] = sg_cut
+            sg_cut_item_data["project"] = sg_project
+            sg_cut_item_data["cut_order"] = item_index + 1
+            if (
+                _ABSOLUTE_CUT_ORDER_FIELD in self.cut_item_schema
+                and linked_entity.get(_ENTITY_CUT_ORDER_FIELD)
+            ):
+                sg_cut_item_data[_ABSOLUTE_CUT_ORDER_FIELD] = (
+                    1000
+                    * linked_entity[_ENTITY_CUT_ORDER_FIELD]
+                    + sg_cut_item_data["cut_order"]
+                )
+
+            # Check if we should update an existing CutItem of create a new one
+            sg_cut_item = cut_item_clips[item_index].metadata.get("sg") or {}
+            if sg_cut_item.get("id"):
+                # Check if the CutItem is linked to the Cut we updated or created.
+                # If not, create a new CutItem.
+                if sg_cut_item.get("cut") and sg_cut_item["cut"].get("id") == sg_cut["id"]:
+                    batch_data.append({
+                        "request_type": "update",
+                        "entity_type": "CutItem",
+                        "entity_id": sg_cut_item["id"],
+                        "data": sg_cut_item_data
+                    })
+                else:
+                    batch_data.append({
+                        "request_type": "create",
+                        "entity_type": "CutItem",
+                        "data": sg_cut_item_data
+                    })
+            else:
+                batch_data.append({
+                    "request_type": "create",
+                    "entity_type": "CutItem",
+                    "data": sg_cut_item_data
+                })
+        sg_cut_items = []
+        if batch_data:
+            res = self._sg.batch(batch_data)
+            for i, sg_cut_item in enumerate(res):
+                # Set the Shot code we don't get back from the batch request
+                if sg_cut_item.get("shot"):
+                    sg_cut_item["shot"]["code"] = shots_by_id[sg_cut_item["shot"]["id"]]["code"]
+                cut_item_clips[i].metadata["sg"] = sg_cut_item
+                sg_cut_items.append(sg_cut_item)
+                logger.info("Updating %s SG metadata with %s" % (cut_item_clips[i].name, sg_cut_item))
+        return sg_cut_items
+
+    def get_sg_cut_item_payload(self, cut_clip, sg_shot=None, sg_user=None):
         """
         Get a SG CutItem payload for a given :class:`sg_otio.CutClip` instance.
 
@@ -90,8 +289,11 @@ class SGCutTrackWriter(object):
         imported against. The absolute cut order is then:
         `1000 * entity cut order + edit cut order`.
 
+        :param cut_clip: A :class:`sg_otio.CutClip` instance.
+        :param sg_shot: An optional SG Shot to use for the CutItem.
+        :param sg_user: An optional user to provide when creating/updating Cut Items in SG.
         :returns: A dictionary with the CutItem payload.
-        :raises ValueError: If no SG payload can be generated for this Clip
+        :raises ValueError: If no SG payload can be generated for this Clip.
         """
         description = ""
         cut_item_payload = {
@@ -123,19 +325,131 @@ class SGCutTrackWriter(object):
                 description,
                 self.effects_str
             )
-        if _EFFECTS_FIELD in self._cut_item_schema:
+        if _EFFECTS_FIELD in self.cut_item_schema:
             cut_item_payload[_EFFECTS_FIELD] = cut_clip.has_effects
 
         if cut_clip.has_retime:
             description = "%s\nRetime: %s" % (description, self.retime_str)
-        if _RETIME_FIELD in self._cut_item_schema:
+        if _RETIME_FIELD in self.cut_item_schema:
             cut_item_payload[_RETIME_FIELD] = cut_clip.has_retime
 
         cut_item_payload["description"] = description
         return cut_item_payload
 
-    def write_to(self, entity_type, entity_id, video_track, sg_user=None, description=""):
+    def _write_shots(self, cut_track, sg_project, sg_linked_entity, sg_user=None):
         """
+        Gather information about SG Shots given a CutTrack, and create or update
+        them accordingly in SG.
+
+        :param cut_track: An instance of :class:`CutTrack`.
+        :param sg_project: The SG Project to write the Cut to.
+        :param sg_cut: If provided, the SG Cut to update.
+        :param sg_linked_entity: If provided, the Entity the Cut will be linked to.
+        :param sg_user: An optional user to provide when creating/updating Entities in SG.
+        :returns: A list of SG Shot Entities.
+        """
+        sg_batch_data = []
+        sg_shots = []
+        existing_shots = self._sg.find(
+            "Shot",
+            [["project", "is", sg_project], ["code", "in", cut_track.shot_names]],
+            ["code"]
+        )
+        existing_shots_by_name = {shot["code"]: shot for shot in existing_shots}
+        for shot in cut_track.shots:
+            if shot.name not in existing_shots_by_name.keys():
+                logger.warning("Will create Shot %s" % shot.name)
+                shot_payload = self._get_shot_payload(shot, sg_project, sg_linked_entity, sg_user)
+                sg_batch_data.append({
+                    "request_type": "create",
+                    "entity_type": "Shot",
+                    "data": shot_payload
+                })
+            else:
+                # TODO: Logic for omitted/reinstated shots
+                sg_shot = existing_shots_by_name[shot.name]
+                shot_payload = self._get_shot_payload(shot, sg_project, sg_linked_entity, sg_user)
+                sg_batch_data.append({
+                    "request_type": "update",
+                    "entity_type": "Shot",
+                    "entity_id": sg_shot["id"],
+                    "data": shot_payload
+                })
+
+        if sg_batch_data:
+            sg_shots = self._sg.batch(sg_batch_data)
+        return sg_shots
+
+    def _get_shot_payload(self, shot, sg_project, sg_linked_entity, sg_user=None):
+        """
+        Get a SG Shot payload for a given :class:`sg_otio.Shot` instance.
+
+        :param shot: A :class:`sg_otio.Shot` instance.
+        :param sg_project: The SG Project to write the Shot to.
+        :param sg_linked_entity: If provided, the Entity the Cut will be linked to.
+        :param sg_user: An optional user to provide when creating/updating Shots in SG.
+        :returns: A dictionary with the Shot payload.
+        """
+        sg_linked_entity = sg_linked_entity or sg_project
+        # TODO: deal with smart fields and shot_cut_fields_prefix
+        sfg = SGShotFieldsConfig(self._sg, sg_linked_entity["type"], use_smart_fields=False, shot_cut_fields_prefix=None)
+        shot_payload = {
+            "project": sg_project,
+            "code": shot.name,
+            sfg.head_in: shot.head_in.to_frames(),
+            sfg.cut_in: shot.cut_in.to_frames(),
+            sfg.cut_out: shot.cut_out.to_frames(),
+            sfg.tail_out: shot.tail_out.to_frames(),
+            sfg.cut_duration: shot.duration.to_frames(),
+            sfg.cut_order: shot.index
+        }
+        if sg_user:
+            shot_payload["created_by"] = sg_user
+            shot_payload["updated_by"] = sg_user
+        if sfg.working_duration:
+            shot_payload[sfg.working_duration] = shot.working_duration.to_frames()
+        if sfg.head_out:
+            shot_payload[sfg.head_out] = shot.head_out.to_frames()
+        if sfg.tail_in:
+            shot_payload[sfg.tail_in] = shot.tail_in.to_frames()
+        if sfg.tail_duration:
+            shot_payload[sfg.tail_duration] = shot.tail_duration.to_frames()
+        # TODO: Add setting for flagging retimes and effects?
+        if True:
+            shot_payload[sfg.has_effects] = shot.has_effects
+            shot_payload[sfg.has_retime] = shot.has_retime
+        if sfg.absolute_cut_order:
+            # TODO: maybe create shot fields config before so that
+            #       we can get the field without an extra query?
+            sg_entity = self._sg.find_one(
+                sg_linked_entity["type"],
+                [["id", "is", sg_linked_entity["id"]]],
+                [sfg.absolute_cut_order]
+            )
+            entity_cut_order = sg_entity.get(sfg.absolute_cut_order)
+            if entity_cut_order:
+                absolute_cut_order = 1000 * entity_cut_order + shot.index
+                shot_payload[sfg.absolute_cut_order] = absolute_cut_order
+        if sfg.shot_link_field and sg_linked_entity:
+            shot_payload[sfg.shot_link_field] = sg_linked_entity
+        return shot_payload
+
+    def _get_cut_entities(self, entity_type, entity_id):
+        """
+        Get the Cut, Project and linked Entity which will be used to create or update
+        the Cut, Shots and CutItems in SG.
+
+        When writing to SG, The Entity provided (type and ID) can be:
+        - The Cut itself
+        - The Project
+        - Any Entity to link the Cut against (e.g. Sequence, Reel...)
+
+        Find these entities and return them.
+
+        :param str entity_type: A SG Entity Type.
+        :param int entity_id: A SG Entity ID.
+        :returns: A tuple (project, sg_cut, sg_linked_entity). The Cut and linked Entity
+                  can be ``None``.
         """
         sg_cut = None
         sg_project = None
@@ -174,134 +488,7 @@ class SGCutTrackWriter(object):
             sg_project = sg_linked_entity["project"]
         if not sg_project:
             raise ValueError("Unable to retrieve a Project from %s %s")
-
-        cut_track = video_track
-        sg_track_data = video_track.metadata.get("sg")
-        if sg_track_data and sg_track_data["type"] != "Cut":
-            raise ValueError(
-                "Invalid {} SG data for a {}".format(sg_track_data["type"], "Cut")
-            )
-        # Convert to a CutTrack if one was not provided.
-        if not isinstance(cut_track, CutTrack):
-            # We need to give the track a parent so time transforms from the Clip
-            # to the track are correctly evaluated.
-            stack = otio.schema.Stack()
-            cut_track = CutTrack.from_track(video_track)
-            stack.append(cut_track)
-
-        sg_cut_data = self.get_sg_cut_payload(cut_track, sg_user, description)
-        shots_by_name = self._create_or_update_sg_shots(
-            cut_track,
-            sg_project,
-            sg_linked_entity,
-            sg_user
-        )
-        shots_by_id = {x["id"]: x for x in shots_by_name.values()}
-        sg_cut_items_data = []
-        cut_item_clips = []
-        # Loop over clips from the cut_track
-        # Keep references to original clips
-        video_clips = list(video_track.each_clip())
-        for i, clip in enumerate(cut_track.each_clip()):
-            if not isinstance(clip, CutClip):
-                continue
-            # Get the SG Shot for this clip
-            sg_shot = shots_by_name.get(clip.shot_name)
-            sg_data = self.get_sg_cut_item_payload(clip, sg_shot=sg_shot)
-            sg_cut_items_data.append(sg_data)
-            # Make sure we keep a reference to the original clip to able to set
-            # SG metadata.
-            cut_item_clips.append(video_clips[i])
-
-#        if input_media_version:
-#            cut_payload["version"] = input_media_version
-        if sg_cut:  # Update existing Cut
-            logger.info("Cut update payload %s" % sg_cut_data)
-            self._sg.update(
-                sg_cut["type"],
-                sg_cut["id"],
-                sg_cut_data,
-            )
-        else:
-            revision_number = 1
-            previous_cut = self._sg.find_one(
-                "Cut",
-                [
-                    ["code", "is", video_track.name],
-                    ["entity", "is", sg_linked_entity or sg_project],
-                ],
-                ["revision_number"],
-                order=[{"field_name": "revision_number", "direction": "desc"}]
-            )
-            if previous_cut:
-                revision_number = (previous_cut.get("revision_number") or 0) + 1
-            # Create a new Cut
-            sg_cut_data["project"] = sg_project
-            sg_cut_data["entity"] = sg_linked_entity or sg_project
-            sg_cut_data["revision_number"] = revision_number
-            logger.info("Cut create payload %s" % sg_cut_data)
-
-            sg_cut = self._sg.create(
-                "Cut",
-                sg_cut_data,
-            )
-            # Update the track with the result
-            logger.info("Updating %s SG metadata with %s" % (video_track, sg_cut))
-            video_track.metadata["sg"] = sg_cut
-        batch_data = []
-        linked_entity = sg_linked_entity or sg_project
-        for item_index, sg_cut_item_data in enumerate(sg_cut_items_data):
-            sg_cut_item_data["cut"] = sg_cut
-            sg_cut_item_data["project"] = sg_project
-            sg_cut_item_data["cut_order"] = item_index + 1
-            if (
-                _ABSOLUTE_CUT_ORDER_FIELD in self._cut_item_schema
-                and linked_entity.get(_ENTITY_CUT_ORDER_FIELD)
-            ):
-                sg_cut_item_data[_ABSOLUTE_CUT_ORDER_FIELD] = (
-                    1000
-                    * linked_entity[_ENTITY_CUT_ORDER_FIELD]
-                    + sg_cut_item_data["cut_order"]
-                )
-
-            # Check if we should update an existing CutItem of create a new one
-            sg_cut_item = cut_item_clips[item_index].metadata.get("sg") or {}
-            if sg_cut_item.get("id"):
-                # Check if the CutItem is linked to the Cut we updated or created.
-                # If not, create a new CutItem.
-                if sg_cut_item.get("cut") and sg_cut_item["cut"].get("id") == sg_cut["id"]:
-                    batch_data.append({
-                        "request_type": "update",
-                        "entity_type": "CutItem",
-                        "entity_id": sg_cut_item["id"],
-                        "data": sg_cut_item_data
-                    })
-                else:
-                    batch_data.append({
-                        "request_type": "create",
-                        "entity_type": "CutItem",
-                        "data": sg_cut_item_data
-                    })
-            else:
-                batch_data.append({
-                    "request_type": "create",
-                    "entity_type": "CutItem",
-                    "data": sg_cut_item_data
-                })
-        if batch_data:
-            res = self._sg.batch(batch_data)
-            # Update the clips SG metadata
-#            for i, (sg_cut_item, new_sg_cut_item) in enumerate(zip(sg_cut_items_data, res)):
-#                # The batch response does not provide all the information
-#                # we had for the Shot. Add it back.
-#                new_sg_cut_item["shot"] = sg_cut_item["shot"]
-#                cut_item_clips[i].metadata["sg"] = new_sg_cut_item
-#                logger.info("Updating %s SG metadata with %s" % (cut_item_clips[i], new_sg_cut_item))
-            for i, sg_cut_item in enumerate(res):
-                # Set the Shot code we don't get back from the batch request
-                sg_cut_item["shot"]["code"] = shots_by_id[sg_cut_item["shot"]["id"]]["code"]
-                cut_item_clips[i].metadata["sg"] = sg_cut_item
-                logger.info("Updating %s SG metadata with %s" % (cut_item_clips[i], sg_cut_item))
+        return sg_project, sg_cut, sg_linked_entity
 
     @staticmethod
     def _retrieve_local_storage(sg, local_storage_name):
@@ -412,111 +599,3 @@ class SGCutTrackWriter(object):
             "sg_uploaded_movie"
         )
         return version, published_file
-
-    def _create_or_update_sg_shots(self, cut_track, sg_project, sg_linked_entity, sg_user=None):
-        """
-        Create or update SG Shots based.
-        """
-        sg_batch_data = []
-        existing_shots = self._sg.find(
-            "Shot",
-            [["project", "is", sg_project], ["code", "in", cut_track.shot_names]],
-            ["code"]
-        )
-        existing_shots_by_name = {shot["code"]: shot for shot in existing_shots}
-        for shot in cut_track.shots:
-            if shot.name not in existing_shots_by_name.keys():
-                logger.warning("Will create Shot %s" % shot.name)
-                shot_payload = self._get_shot_payload(shot, sg_project, sg_linked_entity, sg_user)
-                sg_batch_data.append({
-                    "request_type": "create",
-                    "entity_type": "Shot",
-                    "data": shot_payload
-                })
-            else:
-                # TODO: Logic for omitted/reinstated shots
-                sg_shot = existing_shots_by_name[shot.name]
-                shot_payload = self._get_shot_payload(shot, sg_project, sg_linked_entity, sg_user)
-                sg_batch_data.append({
-                    "request_type": "update",
-                    "entity_type": "Shot",
-                    "entity_id": sg_shot["id"],
-                    "data": shot_payload
-                })
-
-        shots_by_name = {}
-        if sg_batch_data:
-            sg_shots = self._sg.batch(sg_batch_data)
-            for sg_shot in sg_shots:
-                shots_by_name[sg_shot["code"]] = sg_shot
-        return shots_by_name
-
-    def _get_shot_payload(self, shot, sg_project, sg_linked_entity, sg_user=None):
-        """
-        """
-        sg_linked_entity = sg_linked_entity or sg_project
-        # TODO: deal with smart fields and shot_cut_fields_prefix
-        sfg = SGShotFieldsConfig(self._sg, sg_linked_entity["type"], use_smart_fields=False, shot_cut_fields_prefix=None)
-        shot_payload = {
-            "project": sg_project,
-            "code": shot.name,
-            sfg.head_in: shot.head_in.to_frames(),
-            sfg.cut_in: shot.cut_in.to_frames(),
-            sfg.cut_out: shot.cut_out.to_frames(),
-            sfg.tail_out: shot.tail_out.to_frames(),
-            sfg.cut_duration: shot.duration.to_frames(),
-            sfg.cut_order: shot.index
-        }
-        if sg_user:
-            shot_payload["created_by"] = sg_user
-            shot_payload["updated_by"] = sg_user
-        if sfg.working_duration:
-            shot_payload[sfg.working_duration] = shot.working_duration.to_frames()
-        if sfg.head_out:
-            shot_payload[sfg.head_out] = shot.head_out.to_frames()
-        if sfg.tail_in:
-            shot_payload[sfg.tail_in] = shot.tail_in.to_frames()
-        if sfg.tail_duration:
-            shot_payload[sfg.tail_duration] = shot.tail_duration.to_frames()
-        # TODO: Add setting for flagging retimes and effects?
-        if True:
-            shot_payload[sfg.has_effects] = shot.has_effects
-            shot_payload[sfg.has_retime] = shot.has_retime
-        if sfg.absolute_cut_order:
-            # TODO: maybe create shot fields config before so that
-            #       we can get the field without an extra query?
-            sg_entity = self._sg.find_one(
-                sg_linked_entity["type"],
-                [["id", "is", sg_linked_entity["id"]]],
-                [sfg.absolute_cut_order]
-            )
-            entity_cut_order = sg_entity.get(sfg.absolute_cut_order)
-            if entity_cut_order:
-                absolute_cut_order = 1000 * entity_cut_order + shot.index
-                shot_payload[sfg.absolute_cut_order] = absolute_cut_order
-        if sfg.shot_link_field and sg_linked_entity:
-            shot_payload[sfg.shot_link_field] = sg_linked_entity
-        return shot_payload
-
-    def _create_sg_cut_items(self):
-        """
-        Creates SG CutItems for each clip of the input :class:`otio.schema.Timeline` instance.
-
-        :param sg_cut: The SG Cut to create the CutItems for.
-        :returns: A list of SG CutItems.
-        """
-        batch_data = []
-        logger.info("Creating CutItems...")
-        # Get the cut items by name for easy update after creation.
-        cut_items_by_name = dict((val.name, val) for lst in self._cut_items_by_shot.values() for val in lst)
-        for cut_item in cut_items_by_name.values():
-            batch_data.append({
-                "request_type": "create",
-                "entity_type": "CutItem",
-                "data": cut_item.payload
-            })
-        if batch_data:
-            res = self._sg.batch(batch_data)
-            for sg_cut_item in res:
-                cut_item = cut_items_by_name[sg_cut_item["code"]]
-                cut_item.sg_cut_item = sg_cut_item

--- a/sg_otio/sg_settings.py
+++ b/sg_otio/sg_settings.py
@@ -152,6 +152,24 @@ class SGSettings(Singleton("SGSettings", (object,), {})):
         """
         self._clip_name_shot_regexp = value
 
+    @property
+    def local_storage_name(self):
+        """
+        Return the name of the local storage to use when publishing files.
+
+        :returns: A string.
+        """
+        return self._local_storage_name
+
+    @local_storage_name.setter
+    def local_storage_name(self, value):
+        """
+        Set the name of the local storage to use when publishing files.
+
+        :param str value: The name of the local storage to use.
+        """
+        self._local_storage_name = value
+
     def reset_to_defaults(self):
         """
         Reset settings to all default values.
@@ -161,6 +179,7 @@ class SGSettings(Singleton("SGSettings", (object,), {})):
         self._default_tail_out_duration = _DEFAULT_TAIL_OUT_DURATION
         self._use_clip_names_for_shot_names = False
         self._clip_name_shot_regexp = None
+        self._local_storage_name = "primary"
 
 
 class SGShotFieldsConfig(object):

--- a/sg_otio/sg_settings.py
+++ b/sg_otio/sg_settings.py
@@ -4,7 +4,7 @@
 # agreement provided at the time of installation or download, or which otherwise
 # accompanies this software in either electronic or hard copy form.
 #
-
+import json
 import logging
 
 from .constants import _DEFAULT_HEAD_IN, _DEFAULT_HEAD_IN_DURATION, _DEFAULT_TAIL_OUT_DURATION
@@ -40,6 +40,25 @@ class SGSettings(Singleton("SGSettings", (object,), {})):
         Instantiate a new :class:`SGSettings`.
         """
         self.reset_to_defaults()
+
+    @classmethod
+    def from_file(cls, json_file):
+        """
+        Load settings from a JSON file.
+
+        :returns: The :class:`SGSettings` singleton instance.
+        """
+        with open(json_file, "r") as f:
+            json_data = json.loads(f.read())
+        settings = SGSettings()
+        settings.reset_to_defaults()
+        for key, value in json_data.items():
+            if hasattr(settings, key):
+                setattr(settings, key, value)
+            else:
+                raise ValueError("Unknown setting %s with value %s" % (key, value))
+        # We return the settings, but since it's a singleton, it's not really needed.
+        return settings
 
     @property
     def default_head_in(self):

--- a/sg_otio/utils.py
+++ b/sg_otio/utils.py
@@ -1,0 +1,57 @@
+# Copyright 2022 GPL Solutions, LLC.  All rights reserved.
+#
+# Use of this software is subject to the terms of the GPL Solutions license
+# agreement provided at the time of installation or download, or which otherwise
+# accompanies this software in either electronic or hard copy form.
+#
+from six.moves.urllib import parse
+
+
+def get_write_url(sg_site_url, entity_type, entity_id, session_token):
+    """
+    Get the URL to write a Cut to SG.
+
+    The Entity type can be the Cut itself, the Project, or any Entity
+    to link the Cut to (e.g. Sequence, Reel, etc).
+
+    :param str sg_site_url: The SG site URL.
+    :param str entity_type: The SG Entity type to link the Cut to.
+    :param int entity_id: The SG Entity ID.
+    :param str session_token: A SG session token.
+    """
+    # Construct the URL with urlparse
+    parsed_url = parse.urlparse(sg_site_url)
+    query = "session_token=%s&id=%s" % (
+        session_token,
+        entity_id,
+    )
+    # If no scheme was provided, netloc is empty and the whole url is in the path.
+    # So we just append Cut to it.
+    path = "%s/%s" % (parsed_url.path, entity_type)
+    # Make sure to add https:// if the url was provided without it.
+    return parsed_url._replace(
+        scheme="https", query=query, path=path
+    ).geturl()
+
+
+def get_read_url(sg_site_url, cut_id, session_token):
+    """
+    Get the URL to read a Cut from SG.
+
+    :param str sg_site_url: The SG site URL.
+    :param int cut_id: The SG Cut ID.
+    :param str session_token: A SG session token.
+    """
+    # Construct the URL with urlparse
+    parsed_url = parse.urlparse(sg_site_url)
+    query = "session_token=%s&id=%s" % (
+        session_token,
+        cut_id
+    )
+    # If no scheme was provided, netloc is empty and the whole url is in the path.
+    # So we just append Cut to it.
+    path = "%s/Cut" % parsed_url.path
+    # Make sure to add https:// if the url was provided without it.
+    return parsed_url._replace(
+        scheme="https", query=query, path=path
+    ).geturl()

--- a/tests/resources/settings.json
+++ b/tests/resources/settings.json
@@ -1,0 +1,5 @@
+{
+  "default_head_in": 1,
+  "default_head_in_duration": 10,
+  "default_tail_out_duration": 10
+}

--- a/tests/test_clip_group.py
+++ b/tests/test_clip_group.py
@@ -13,6 +13,14 @@ from sg_otio.sg_settings import SGSettings
 
 
 class TestClipGroup(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Setup the tests suite.
+        """
+        sg_settings = SGSettings()
+        sg_settings.reset_to_defaults()
+
     def test_shot_clips(self):
         """
         Test that when loading a timeline, it detects the shots belonging to the tracks,

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -16,6 +16,14 @@ from sg_otio.sg_settings import SGSettings
 
 
 class TestCutClip(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Setup the tests suite.
+        """
+        sg_settings = SGSettings()
+        sg_settings.reset_to_defaults()
+
     def test_clip_name(self):
         """
         Test that the name does come from the reel name if available,
@@ -189,6 +197,7 @@ class TestCutClip(unittest.TestCase):
         # set non_default head_in, head_in_duration, tail_out_duration
         # to show that the results are still consistent.
         sg_settings = SGSettings()
+        sg_settings.use_clip_names_for_shot_names = False
         sg_settings.default_head_in = 555
         sg_settings.default_head_in_duration = 10
         sg_settings.default_tail_out_duration = 20
@@ -198,6 +207,10 @@ class TestCutClip(unittest.TestCase):
         )
         clips = list(timeline.tracks[0].each_clip())
         self.assertEqual(len(clips), 3)
+        # FIXME: the transition is added as a Clip in the CutTrack, with an empty
+        # Shot name.
+        for clip in clips:
+            self.assertIsNotNone(clip.shot_name)
         clip_1 = clips[0]
         # The normal duration is 24 frames plus the in offset of the transition
         self.assertEqual(clip_1.duration().to_frames(), 36)
@@ -214,7 +227,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip_1.edit_out.to_frames(), 48)
         self.assertTrue(clip_1.has_effects)
         self.assertEqual(clip_1.effects_str, "After: SMPTE_Dissolve (12 frames)")
-
+        self.assertEqual(clip_1.shot_name, "shot_001")
         # This is the transition clip. It has a duration of 1 second.
         clip_2 = clips[1]
         # The duration only takes into account the transition out_offset

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -94,7 +94,7 @@ class TestCutClip(unittest.TestCase):
         clip.metadata["sg"] = {
             "type": "CutItem",
             "id": 123456,
-            "shot.Shot.code": "shot_from_SG"
+            "shot": {"code": "shot_from_SG"}
         }
         clip._compute_shot_name()
         self.assertEqual(clip.shot_name, "shot_from_SG")

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -137,7 +137,6 @@ class ShotgridAdapterTest(unittest.TestCase):
                     "timecode_edit_in_text": "01:%02d:00:00" % i,
                     "timecode_edit_out_text": "01:%02d:00:00" % (i + 1),
                     "shot": shot,
-                    "shot.Shot.code": shot["code"],
                     "version": version,
                     "version.Version.code": version["code"],
                     "version.Version.entity": version["entity"],
@@ -353,7 +352,7 @@ class ShotgridAdapterTest(unittest.TestCase):
                     if field not in [
                         "id", "cut", "created_by", "updated_by", "updated_at", "created_at",
                         # Not yet implemented
-                        "shot", "shot.Shot.code", "version", "version.Version.code", "version.Version.entity",
+                        "shot", "version", "version.Version.code", "version.Version.entity",
                         "version.Version.image",
                     ]:
                         logger.info(

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -32,7 +32,9 @@ class ShotgridAdapterTest(unittest.TestCase):
         Setup the tests suite.
         """
         self.maxDiff = None
-        SGSettings().reset_to_defaults()
+        sg_settings = SGSettings()
+        sg_settings.reset_to_defaults()
+        sg_settings.use_clip_names_for_shot_names = True
         # Retrieve SG credentials from the environment
         # The SG site
         self._SG_SITE = os.getenv("SG_TEST_SITE") or "https://mysite.shotgunstudio.com"
@@ -137,6 +139,7 @@ class ShotgridAdapterTest(unittest.TestCase):
                     "timecode_edit_in_text": "01:%02d:00:00" % i,
                     "timecode_edit_out_text": "01:%02d:00:00" % (i + 1),
                     "shot": shot,
+                    "shot.Shot.code": shot["code"],
                     "version": version,
                     "version.Version.code": version["code"],
                     "version.Version.entity": version["entity"],
@@ -350,13 +353,13 @@ class ShotgridAdapterTest(unittest.TestCase):
                 for field in _CUT_ITEM_FIELDS:
 
                     if field not in [
-                        "id", "cut", "created_by", "updated_by", "updated_at", "created_at",
+                        "id", "cut", "created_by", "updated_by", "updated_at", "created_at", "shot.Shot.code",
                         # Not yet implemented
-                        "shot", "version", "version.Version.code", "version.Version.entity",
+                        "version", "version.Version.code", "version.Version.entity",
                         "version.Version.image",
                     ]:
                         logger.info(
-                            "Checking item %d %s %s %s" % (i, field, sg_cut_item[field], self.mock_cut_items[i][field])
+                            "Checking item %d %s %s vs %s" % (i, field, sg_cut_item[field], self.mock_cut_items[i][field])
                         )
                         if isinstance(sg_cut_item[field], dict):
                             self.assertEqual(

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -138,6 +138,8 @@ class ShotgridAdapterTest(unittest.TestCase):
                     "timecode_cut_item_out_text": "00:01:00:00",
                     "timecode_edit_in_text": "01:%02d:00:00" % i,
                     "timecode_edit_out_text": "01:%02d:00:00" % (i + 1),
+                    "edit_in": i * (self.fps * 60) + 1,
+                    "edit_out": (i + 1) * (self.fps * 60),
                     "shot": shot,
                     "shot.Shot.code": shot["code"],
                     "version": version,
@@ -274,6 +276,177 @@ class ShotgridAdapterTest(unittest.TestCase):
                     self.fps
                 )
             )
+
+    def test_read_raises_error_if_overlap(self):
+        """
+        Test reading a SG Cut with overlapping cut items.
+        """
+        mock_cut_id = 1000
+        mock_cut = {
+            "type": "Cut",
+            "id": mock_cut_id,
+            "code": "Cut_Overlapping_cut_items",
+            "project": self.mock_project,
+            "fps": self.fps,
+            "timecode_start_text": "01:00:00:00",
+            "timecode_end_text": "01:02:00:00",  # 5760 frames at 24 fps.
+            "revision_number": 1,
+            "entity": self.mock_sequence,
+            "sg_status_list": "ip",
+            "image": None,
+            "description": "Mocked Cut",
+        }
+        # When edit in and edit out are provided, the overlap is calculated with the edit in and out,
+        # not the text fields.
+        # SG, for edit_in and edit_out, adds 1 frame to the next edit_in, e.g. first clip 1-24, next
+        # clip 25-48, etc.
+        mock_cut_items = [
+            {
+                "type": "CutItem",
+                "id": 1000,
+                "code": "first",
+                "cut": mock_cut,
+                "timecode_cut_item_in_text": "00:00:00:00",
+                "timecode_cut_item_out_text": "00:01:00:00",
+                "timecode_edit_in_text": "01:00:00:00",
+                "timecode_edit_out_text": "01:01:00:00",
+                "edit_in": 1,
+                "edit_out": 24,
+                "cut_order": 1,
+            },
+            {
+                "type": "CutItem",
+                "id": 1001,
+                "code": "second",
+                "cut": mock_cut,
+                "timecode_cut_item_in_text": "00:00:00:00",
+                "timecode_cut_item_out_text": "00:01:00:00",
+                # One frame overlap with previous
+                "timecode_edit_in_text": "01:00:59:00",
+                "timecode_edit_out_text": "01:02:00:00",
+                "edit_in": 24,
+                "edit_out": 48,
+                "cut_order": 2,
+            }
+        ]
+        try:
+            self._add_to_sg_mock_db(self.mock_sg, mock_cut)
+            self._add_to_sg_mock_db(self.mock_sg, mock_cut_items)
+            SG_CUT_URL = "{}/Cut?session_token={}&id={}".format(
+                self._SG_SITE,
+                self._SESSION_TOKEN,
+                mock_cut_id
+            )
+            with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+                with self.assertRaises(ValueError) as cm:
+                    otio.adapters.read_from_file(
+                        SG_CUT_URL,
+                        "ShotGrid",
+                    )
+                self.assertIn(
+                    "Overlapping cut items detected",
+                    str(cm.exception)
+                )
+
+            # Now test with the edit in and edit out text fields.
+            self.mock_sg.update("CutItem", 1000, {"edit_out": None})
+            self.mock_sg.update("CutItem", 1001, {"edit_in": None})
+            with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+                with self.assertRaises(ValueError) as cm:
+                    otio.adapters.read_from_file(
+                        SG_CUT_URL,
+                        "ShotGrid",
+                    )
+                self.assertIn(
+                    "Overlapping cut items detected",
+                    str(cm.exception)
+                )
+        finally:
+            self.mock_sg.delete("Cut", mock_cut_id)
+            self.mock_sg.delete("CutItem", 1000)
+            self.mock_sg.delete("CutItem", 1001)
+
+    def test_read_adds_gap(self):
+        """
+        Test that reading a SG Cut with gaps also adds gaps to the track.
+        """
+        mock_cut_id = 1000
+        mock_cut = {
+            "type": "Cut",
+            "id": mock_cut_id,
+            "code": "Cut_with_gaps",
+            "project": self.mock_project,
+            "fps": self.fps,
+            "timecode_start_text": "01:00:00:00",
+            "timecode_end_text": "01:03:00:00",  # 5760 frames at 24 fps.
+            "revision_number": 1,
+            "entity": self.mock_sequence,
+            "sg_status_list": "ip",
+            "image": None,
+            "description": "Mocked Cut",
+        }
+        mock_cut_items = [
+            {
+                "type": "CutItem",
+                "id": 1000,
+                "code": "first",
+                "cut": mock_cut,
+                "timecode_cut_item_in_text": "00:00:00:00",
+                "timecode_cut_item_out_text": "00:01:00:00",
+                "timecode_edit_in_text": "01:00:00:00",
+                "timecode_edit_out_text": "01:01:00:00",
+                "edit_in": 1,
+                "edit_out": 24,
+                "cut_order": 1,
+            },
+            {
+                "type": "CutItem",
+                "id": 1001,
+                "code": "second",
+                "cut": mock_cut,
+                "timecode_cut_item_in_text": "00:00:00:00",
+                "timecode_cut_item_out_text": "00:01:00:00",
+                "timecode_edit_in_text": "01:02:00:00",
+                "timecode_edit_out_text": "01:03:00:00",
+                "edit_in": 49,
+                "edit_out": 72,
+                "cut_order": 2,
+            }
+        ]
+        try:
+            self._add_to_sg_mock_db(self.mock_sg, mock_cut)
+            self._add_to_sg_mock_db(self.mock_sg, mock_cut_items)
+            SG_CUT_URL = "{}/Cut?session_token={}&id={}".format(
+                self._SG_SITE,
+                self._SESSION_TOKEN,
+                mock_cut_id
+            )
+            with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+                timeline = otio.adapters.read_from_file(
+                    SG_CUT_URL,
+                    "ShotGrid",
+                )
+            tracks = list(timeline.tracks)
+            self.assertEqual(len(tracks), 1)
+            track = tracks[0]
+            clips = list(track.each_clip())
+            self.assertEqual(len(clips), 2)
+            children = list(track.each_child())
+            self.assertEqual(len(children), 3)
+            print("HERE", children)
+            self.assertTrue(isinstance(children[0], otio.schema.Clip))
+            self.assertTrue(isinstance(children[2], otio.schema.Clip))
+            gap = children[1]
+            self.assertTrue(isinstance(gap, otio.schema.Gap))
+            source_range = otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, self.fps),
+                duration=otio.opentime.RationalTime(24, self.fps)
+            )
+            self.assertEqual(gap.source_range, source_range)
+        finally:
+            self.mock_sg.delete("Cut", mock_cut_id)
+            self.mock_sg.delete("CutItem", 1000)
+            self.mock_sg.delete("CutItem", 1001)
 
     def test_read_write_sg_cut(self):
         """


### PR DESCRIPTION
I did two commits:

- The first one is for the writer, and I think the code here is solid
- The second one is for the reader, and it is a bit less straightforward: We were adding for example the shot code by getting the field "shot.Shot.code", but if you want to have a bunch of these, it seems better to get the shot entity than to get all the individual fields. But I'm not sure it's the right approach, and it makes the linking of the sg_cut_item metadata to the clip a bit weird, since when you update a cut_item's shot field, when you get it back, you only have the id and the type... I'm pretty sure what I did there is wrong.


Let's talk to see if the direction seems OK