### PR TITLE
Ffmpeg GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install ffmpeg
+        uses: FedericoCarboni/setup-ffmpeg@v1
+        id: setup-ffmpeg
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
- Install ffmpeg in github actions to be able to run tests that depend on ffmpeg and ffprobe
- Tested by testing a PR to master, this launches the tests, and the ffmpeg/ffprobe tests pass, and the time impact is close to null

Note that we still have one failing test, but it's not because of the lack of ffmpeg.