### PR TITLE
For #8462 unittests, fixed some bugs.

### DIFF
--- a/sg_otio/clip_group.py
+++ b/sg_otio/clip_group.py
@@ -227,7 +227,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         the source_in of the group is the smallest source_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.source_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.source_in`
 
         :returns: A :class:`otio.schema.TimeRange` instance.
         """
@@ -241,7 +241,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         the source_out of the group is the largest source_out of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.source_out`
+        ..seealso:: :attr:`sg_otio.SGCutClip.source_out`
 
         :returns: A :class:`otio.schema.TimeRange` instance.
         """
@@ -255,7 +255,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         the cut_in of the group is the smallest cut_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.cut_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.cut_in`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -269,7 +269,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         the cut_out of the group is the largest cut_out of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.cut_out`
+        ..seealso:: :attr:`sg_otio.SGCutClip.cut_out`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -283,7 +283,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         the head_in of the group is the smallest head_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.head_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.head_in`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -312,8 +312,8 @@ class ClipGroup(object):
         The head duration is the difference between the largest head_out of the group's clips
         and the smallest head_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.head_in`
-        ..seealso:: :attr:`sg_otio.ExtendedClip.head_out`
+        ..seealso:: :attr:`sg_otio.SGCutClip.head_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.head_out`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -327,7 +327,7 @@ class ClipGroup(object):
         Since the group values cover the range of all clips,
         The tail in is the largest tail_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.tail_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.tail_in`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -354,8 +354,8 @@ class ClipGroup(object):
         The tail duration is the difference between the largest tail_out of the group's clips
         and the smallest tail_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.tail_in`
-        ..seealso:: :attr:`sg_otio.ExtendedClip.tail_out`
+        ..seealso:: :attr:`sg_otio.SGCutClip.tail_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.tail_out`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
@@ -389,9 +389,9 @@ class ClipGroup(object):
         The visible duration is the difference between the largest cut_out of the group's clips
         and the smallest cut_in of the group's clips.
 
-        ..seealso:: :attr:`sg_otio.ExtendedClip.visible_duration`
-        ..seealso:: :attr:`sg_otio.ExtendedClip.cut_in`
-        ..seealso:: :attr:`sg_otio.ExtendedClip.cut_out`
+        ..seealso:: :attr:`sg_otio.SGCutClip.visible_duration`
+        ..seealso:: :attr:`sg_otio.SGCutClip.cut_in`
+        ..seealso:: :attr:`sg_otio.SGCutClip.cut_out`
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -723,7 +723,7 @@ class SGCutClip(object):
         if timecode_in_to_frame_mapping_mode == _TC2FRAME_RELATIVE_MODE:
             tc_base, frame = sg_settings.timecode_in_to_frame_relative_mapping
             tc_base = otio.opentime.from_timecode(tc_base, self._frame_rate)
-            logger.info("Using mapping %s %s" % (tc_base, frame))
+            logger.debug("Using mapping %s %s" % (tc_base, frame))
             return self.source_in - tc_base + RationalTime(frame, self._frame_rate)
 
         # Automatic mode

--- a/sg_otio/sg_settings.py
+++ b/sg_otio/sg_settings.py
@@ -410,15 +410,23 @@ class SGShotFieldsConfig(object):
         self.validate_shot_cut_fields_prefix(sg_settings.shot_cut_fields_prefix)
         self._shot_cut_fields_prefix = sg_settings.shot_cut_fields_prefix
         self._sg_shot_link_field = None
-        self._shot_schema = None
+        self.cache_shot_schema()
+
+    def cache_shot_schema(self):
+        """
+        Cache the schema for the Shot entity, if possible.
+        """
+        if self._sg and self._shot_schema is None:
+            # For some reason, setting self._shot_schema does not set it at the
+            # class level.
+            SGShotFieldsConfig._shot_schema = self._sg.schema_field_read("Shot")
+        return self._shot_schema
 
     @property
     def shot_schema(self):
         """
-        Return the schema for the Shot entity.
+        Return the schema for the Shot entity or ``None``.
         """
-        if self._shot_schema is None:
-            self._shot_schema = self._sg.schema_field_read("Shot")
         return self._shot_schema
 
     @property

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -284,7 +284,7 @@ class SGTrackDiff(object):
         self._diffs_by_shots = {}
         # Retrieve the Shot fields we need to query from SG.
         sg_shot_fields = SGShotFieldsConfig(
-            None, None
+            self._sg, None
         ).all
 
         # Retrieve SG Entities from the old_track
@@ -702,21 +702,21 @@ class SGTrackDiff(object):
             # And then counts and lists per type of changes
             self.count_for_type(_DIFF_TYPES.NEW),
             "\n".join([
-                diff.name for diff in sorted(
+                diff.shot_name for diff in sorted(
                     self.diffs_for_type(_DIFF_TYPES.NEW, just_earliest=True),
                     key=lambda x: x.index
                 )
             ]),
             self.count_for_type(_DIFF_TYPES.OMITTED),
             "\n".join([
-                diff.name for diff in sorted(
+                diff.shot_name for diff in sorted(
                     self.diffs_for_type(_DIFF_TYPES.OMITTED, just_earliest=True),
                     key=lambda x: x.index or -1
                 )
             ]),
             self.count_for_type(_DIFF_TYPES.REINSTATED),
             "\n".join([
-                diff.name for diff in sorted(
+                diff.shot_name for diff in sorted(
                     self.diffs_for_type(_DIFF_TYPES.REINSTATED, just_earliest=True),
                     key=lambda x: x.index
                 )

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -510,8 +510,8 @@ class SGTrackDiff(object):
         """
         return self._diffs_by_shots
 
-    @staticmethod
-    def old_clip_for_shot(for_clip, prev_clip_list, sg_shot, sg_version=None):
+    @classmethod
+    def old_clip_for_shot(cls, for_clip, prev_clip_list, sg_shot, sg_version=None):
         """
         Return a Clip for the given Clip and Shot from the given list of Clip list.
 
@@ -552,7 +552,7 @@ class SGTrackDiff(object):
                     # give score a bonus as we don't have an explicit mismatch
                     potential_matches.append((
                         clip,
-                        100 + SGTrackDiff._get_matching_score(clip, for_clip)
+                        100 + cls._get_matching_score(clip, for_clip)
                     ))
                 elif sg_cut_item["version"]:
                     if sg_version["id"] == sg_cut_item["version"]["id"]:
@@ -560,13 +560,13 @@ class SGTrackDiff(object):
                         # Version
                         potential_matches.append((
                             clip,
-                            1000 + SGTrackDiff._get_matching_score(clip, for_clip)
+                            1000 + cls._get_matching_score(clip, for_clip)
                         ))
                     else:
                         # Version mismatch, don't give any bonus
                         potential_matches.append((
                             clip,
-                            SGTrackDiff._get_matching_score(clip, for_clip)
+                            cls._get_matching_score(clip, for_clip)
                         ))
                 else:
                     # Will keep looking around but we keep a reference to
@@ -575,7 +575,7 @@ class SGTrackDiff(object):
                     # mismatch
                     potential_matches.append((
                         clip,
-                        100 + SGTrackDiff._get_matching_score(clip, for_clip)
+                        100 + cls._get_matching_score(clip, for_clip)
                     ))
             else:
                 logger.debug("Rejecting %s for %s" % (clip.cut_item_name, for_clip.cut_item_name))
@@ -776,8 +776,8 @@ class SGTrackDiff(object):
         )
         return diff_groups
 
-    @staticmethod
-    def _get_matching_score(clip_a, clip_b):
+    @classmethod
+    def _get_matching_score(cls, clip_a, clip_b):
         """
         Return a matching score for the given two clips, based on:
         - Is the Cut order the same?

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -510,7 +510,8 @@ class SGTrackDiff(object):
         """
         return self._diffs_by_shots
 
-    def old_clip_for_shot(self, for_clip, prev_clip_list, sg_shot, sg_version=None):
+    @staticmethod
+    def old_clip_for_shot(for_clip, prev_clip_list, sg_shot, sg_version=None):
         """
         Return a Clip for the given Clip and Shot from the given list of Clip list.
 
@@ -551,7 +552,7 @@ class SGTrackDiff(object):
                     # give score a bonus as we don't have an explicit mismatch
                     potential_matches.append((
                         clip,
-                        100 + self._get_matching_score(clip, for_clip)
+                        100 + SGTrackDiff._get_matching_score(clip, for_clip)
                     ))
                 elif sg_cut_item["version"]:
                     if sg_version["id"] == sg_cut_item["version"]["id"]:
@@ -559,13 +560,13 @@ class SGTrackDiff(object):
                         # Version
                         potential_matches.append((
                             clip,
-                            1000 + self._get_matching_score(clip, for_clip)
+                            1000 + SGTrackDiff._get_matching_score(clip, for_clip)
                         ))
                     else:
                         # Version mismatch, don't give any bonus
                         potential_matches.append((
                             clip,
-                            self._get_matching_score(clip, for_clip)
+                            SGTrackDiff._get_matching_score(clip, for_clip)
                         ))
                 else:
                     # Will keep looking around but we keep a reference to
@@ -574,7 +575,7 @@ class SGTrackDiff(object):
                     # mismatch
                     potential_matches.append((
                         clip,
-                        100 + self._get_matching_score(clip, for_clip)
+                        100 + SGTrackDiff._get_matching_score(clip, for_clip)
                     ))
             else:
                 logger.debug("Rejecting %s for %s" % (clip.cut_item_name, for_clip.cut_item_name))
@@ -775,7 +776,8 @@ class SGTrackDiff(object):
         )
         return diff_groups
 
-    def _get_matching_score(self, clip_a, clip_b):
+    @staticmethod
+    def _get_matching_score(clip_a, clip_b):
         """
         Return a matching score for the given two clips, based on:
         - Is the Cut order the same?

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -14,8 +14,9 @@ from opentimelineio.opentime import TimeRange, RationalTime
 from sg_otio.track_diff import SGTrackDiff
 from sg_otio.cut_diff import SGCutDiff
 from sg_otio.utils import get_read_url, get_write_url
-from sg_otio.constants import _DIFF_TYPES
-from sg_otio.sg_settings import SGSettings
+from sg_otio.constants import _DIFF_TYPES, _ALT_SHOT_FIELDS
+from sg_otio.constants import _TC2FRAME_ABSOLUTE_MODE, _TC2FRAME_AUTOMATIC_MODE, _TC2FRAME_RELATIVE_MODE
+from sg_otio.sg_settings import SGSettings, SGShotFieldsConfig
 
 
 try:
@@ -168,6 +169,28 @@ class TestCutDiff(SGBaseTest):
         }]
         self.add_to_sg_mock_db(self.sg_cut_items)
         self._sg_entities_to_delete.extend(self.sg_cut_items)
+
+    @staticmethod
+    def _mock_compute_clip_shot_name(clip):
+        """
+        Override compute clip shot name to get a unique shot name per clip.
+        """
+        return "shot_%d" % (6665 + list(clip.parent().each_clip()).index(clip) + 1)
+
+    def _get_track_diff(self, new_track, old_track=None, mock_compute_clip_shot_name=None):
+        """
+        Create a track diff altering the shot names so that there's
+        :param new_track:
+        :param old_track:
+        :return:
+        """
+        with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+            if mock_compute_clip_shot_name:
+                with mock.patch("sg_otio.track_diff.compute_clip_shot_name", wraps=mock_compute_clip_shot_name):
+                    with mock.patch("sg_otio.cut_clip.compute_clip_shot_name", wraps=mock_compute_clip_shot_name):
+                        return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track)
+            else:
+                return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track)
 
     def tearDown(self):
         """
@@ -818,16 +841,112 @@ class TestCutDiff(SGBaseTest):
             "edls",
             "R7v26.0_Turnover001_WiP_VFX__1_.edl"
         )
-        with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
-            timeline_from_edl = otio.adapters.read_from_file(path)
-            new_track = timeline_from_edl.tracks[0]
-            track_diff = SGTrackDiff(
-                self.mock_sg,
-                self.mock_project,
-                new_track=new_track,
-                old_track=sg_track,
+        timeline_from_edl = otio.adapters.read_from_file(path)
+        new_track = timeline_from_edl.tracks[0]
+        track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
+
+        # 4 shots exist in the DB, from shot_6666 to shot_6669
+        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
+        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
+        report = track_diff.get_report("This is a Test", [])
+        self.assertEqual(
+            report,
+            (
+                "Sequence Cut Summary changes on This is a Test",
+                (
+                    "\n\nLinks: \n\nThe changes in This is a Test are as follows:\n\n"
+                    "28 New Shots\n%s\n\n"
+                    "0 Omitted Shots\n\n\n"
+                    "0 Reinstated Shot\n\n\n"
+                    "0 Cut Changes\n\n\n"
+                    "0 Rescan Needed\n\n\n"
+                ) % "\n".join(["shot_%d" % (6670 + i) for i in range(28)])
             )
-        # FIXME: we don't get the right results here (no changes)
-        # sg_otio.utils.compute_clip_shot_name must be patched.
-        for diff_type, items in track_diff.get_diffs_by_change_type().items():
-            logger.info("%s" % items)
+        )
+        SGSettings().shot_cut_fields_prefix = "myprecious"
+
+        timeline_from_edl = otio.adapters.read_from_file(path)
+        new_track = timeline_from_edl.tracks[0]
+        # Check that using custom Shot cut fields is handled
+        # Validation should fail
+        with self.assertRaisesRegexp(
+                ValueError,
+                "Following SG Shot fields are missing",
+        ):
+            self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
+        # Bypass validation and check the fields are passed through
+        with mock.patch.object(SGShotFieldsConfig, "validate_shot_cut_fields_prefix"):
+            track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
+        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
+        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
+
+        # Check the custom fields were queried
+        expected = [x % "myprecious" for x in _ALT_SHOT_FIELDS]
+        for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NO_CHANGE):
+            self.assertTrue(
+                all([x in cut_diff.sg_shot for x in expected])
+            )
+        # Check summary CutDiff iteration and Shot values
+        for i, (shot_name, clip_group) in enumerate(track_diff.items()):
+            self.assertEqual(len(clip_group), 1)
+            cut_diff = clip_group[0]
+            if i < 4:
+                sg_shot = clip_group.sg_shot
+                self.assertEqual(sg_shot["id"], self.sg_shots[i]["id"])
+                self.assertTrue("sg_myprecious_cut_out" in sg_shot)
+                self.assertTrue("sg_myprecious_status_list" in sg_shot)
+                self.assertTrue("sg_myprecious_working_duration" in sg_shot)
+                self.assertTrue("sg_myprecious_head_in" in sg_shot)
+                self.assertTrue("sg_myprecious_cut_duration" in sg_shot)
+                self.assertTrue("sg_myprecious_cut_order" in sg_shot)
+                self.assertTrue("sg_myprecious_tail_out" in sg_shot)
+                self.assertTrue("sg_myprecious_cut_in" in sg_shot)
+                self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NO_CHANGE)
+                self.assertEqual(clip_group.index, i + 1)
+                # FIXME: fails with 1001 != 1000 (taken from tk-framework-editorial)
+                # self.assertEqual(clip_group.head_in.to_frames(), self.sg_cut_items[i]["cut_item_in"] - 8)
+                self.assertEqual(clip_group.cut_in.to_frames(), self.sg_cut_items[i]["cut_item_in"])
+                self.assertEqual(clip_group.cut_out.to_frames(), self.sg_cut_items[i]["cut_item_out"])
+                # FIXME: tail out won't work because of our shot cut fields prefix and the fact that CutClip.tail_out
+                #  relies on SGShotFieldsConfig(None, None)...
+                # self.assertEqual(clip_group.tail_out.to_frames(), self.sg_cut_items[i]["cut_item_out"] + 8)
+            else:
+                self.assertIsNone(clip_group.sg_shot)
+                self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NEW)
+
+    def test_timecode_frame_mapping_modes(self):
+        """
+        Test the different mapping modes.
+        """
+        self._add_sg_cut_data()
+        SGSettings().timecode_in_to_frame_mapping_mode = _TC2FRAME_AUTOMATIC_MODE
+        path = os.path.join(
+            self.resources_dir,
+            "edls",
+            "R7v26.0_Turnover001_WiP_VFX__1_.edl"
+        )
+
+        timeline_from_edl = otio.adapters.read_from_file(path)
+        new_track = timeline_from_edl.tracks[0]
+        track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
+            self.assertEqual(1009, cut_diff.cut_in.to_frames())
+
+        SGSettings().timecode_in_to_frame_mapping_mode = _TC2FRAME_RELATIVE_MODE
+        SGSettings().timecode_in_to_frame_relative_mapping = (
+            "00:00:00:10",  # 10 frames
+            100,
+        )
+        track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
+            self.assertEqual(
+                cut_diff.source_in.to_frames() - 10 + 100,
+                cut_diff.cut_in.to_frames()
+            )
+        SGSettings().timecode_in_to_frame_mapping_mode = _TC2FRAME_ABSOLUTE_MODE
+        track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
+            self.assertEqual(
+                cut_diff.source_in.to_frames(),
+                cut_diff.cut_in.to_frames()
+            )

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -879,6 +879,10 @@ class TestCutDiff(SGBaseTest):
         """
         Test generating a diff report.
         """
+        settings = SGSettings()
+        settings.default_head_in = 1000
+        settings.default_head_in_duration = 8
+        settings.default_tail_out_duration = 8
         self._add_sg_cut_data()
         with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
             mock_cut_url = get_read_url(
@@ -996,8 +1000,7 @@ class TestCutDiff(SGBaseTest):
                     self.assertTrue("sg_myprecious_cut_in" in sg_shot)
                     self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NO_CHANGE)
                     self.assertEqual(clip_group.index, i + 1)
-                    # FIXME: fails with 1001 != 1000 (taken from tk-framework-editorial)
-                    # self.assertEqual(clip_group.head_in.to_frames(), self.sg_cut_items[i]["cut_item_in"] - 8)
+                    self.assertEqual(clip_group.head_in.to_frames(), self.sg_cut_items[i]["cut_item_in"] - 8)
                     self.assertEqual(clip_group.cut_in.to_frames(), self.sg_cut_items[i]["cut_item_in"])
                     self.assertEqual(clip_group.cut_out.to_frames(), self.sg_cut_items[i]["cut_item_out"])
                     self.assertEqual(clip_group.tail_out.to_frames(), self.sg_cut_items[i]["cut_item_out"] + 8)

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -181,9 +181,11 @@ class TestCutDiff(SGBaseTest):
     def _get_track_diff(self, new_track, old_track=None, mock_compute_clip_shot_name=None):
         """
         Create a track diff altering the shot names so that there's
-        :param new_track:
-        :param old_track:
-        :return:
+
+        :param new_track: A :class:`opentimelineio.schema.Track` instance.
+        :param old_track: An optional :class:`opentimelineio.schema.Track` instance
+                          read from SG.
+        :returns: A :class:`SGTrackDiff` instance.
         """
         with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
             if mock_compute_clip_shot_name:
@@ -961,8 +963,8 @@ class TestCutDiff(SGBaseTest):
         # Check that using custom Shot cut fields is handled
         # Validation should fail
         with self.assertRaisesRegexp(
-                ValueError,
-                "Following SG Shot fields are missing",
+            ValueError,
+            "Following SG Shot fields are missing",
         ):
             self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
         # Bypass validation and check the fields are passed through

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -877,42 +877,40 @@ class TestCutDiff(SGBaseTest):
         # Bypass validation and check the fields are passed through
         with mock.patch.object(SGShotFieldsConfig, "validate_shot_cut_fields_prefix"):
             track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
-        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
-        self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
+            self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
+            self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
 
-        # Check the custom fields were queried
-        expected = [x % "myprecious" for x in _ALT_SHOT_FIELDS]
-        for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NO_CHANGE):
-            self.assertTrue(
-                all([x in cut_diff.sg_shot for x in expected])
-            )
-        # Check summary CutDiff iteration and Shot values
-        for i, (shot_name, clip_group) in enumerate(track_diff.items()):
-            self.assertEqual(len(clip_group), 1)
-            cut_diff = clip_group[0]
-            if i < 4:
-                sg_shot = clip_group.sg_shot
-                self.assertEqual(sg_shot["id"], self.sg_shots[i]["id"])
-                self.assertTrue("sg_myprecious_cut_out" in sg_shot)
-                self.assertTrue("sg_myprecious_status_list" in sg_shot)
-                self.assertTrue("sg_myprecious_working_duration" in sg_shot)
-                self.assertTrue("sg_myprecious_head_in" in sg_shot)
-                self.assertTrue("sg_myprecious_cut_duration" in sg_shot)
-                self.assertTrue("sg_myprecious_cut_order" in sg_shot)
-                self.assertTrue("sg_myprecious_tail_out" in sg_shot)
-                self.assertTrue("sg_myprecious_cut_in" in sg_shot)
-                self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NO_CHANGE)
-                self.assertEqual(clip_group.index, i + 1)
-                # FIXME: fails with 1001 != 1000 (taken from tk-framework-editorial)
-                # self.assertEqual(clip_group.head_in.to_frames(), self.sg_cut_items[i]["cut_item_in"] - 8)
-                self.assertEqual(clip_group.cut_in.to_frames(), self.sg_cut_items[i]["cut_item_in"])
-                self.assertEqual(clip_group.cut_out.to_frames(), self.sg_cut_items[i]["cut_item_out"])
-                # FIXME: tail out won't work because of our shot cut fields prefix and the fact that CutClip.tail_out
-                #  relies on SGShotFieldsConfig(None, None)...
-                # self.assertEqual(clip_group.tail_out.to_frames(), self.sg_cut_items[i]["cut_item_out"] + 8)
-            else:
-                self.assertIsNone(clip_group.sg_shot)
-                self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NEW)
+            # Check the custom fields were queried
+            expected = [x % "myprecious" for x in _ALT_SHOT_FIELDS]
+            for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NO_CHANGE):
+                self.assertTrue(
+                    all([x in cut_diff.sg_shot for x in expected])
+                )
+            # Check summary CutDiff iteration and Shot values
+            for i, (shot_name, clip_group) in enumerate(track_diff.items()):
+                self.assertEqual(len(clip_group), 1)
+                cut_diff = clip_group[0]
+                if i < 4:
+                    sg_shot = clip_group.sg_shot
+                    self.assertEqual(sg_shot["id"], self.sg_shots[i]["id"])
+                    self.assertTrue("sg_myprecious_cut_out" in sg_shot)
+                    self.assertTrue("sg_myprecious_status_list" in sg_shot)
+                    self.assertTrue("sg_myprecious_working_duration" in sg_shot)
+                    self.assertTrue("sg_myprecious_head_in" in sg_shot)
+                    self.assertTrue("sg_myprecious_cut_duration" in sg_shot)
+                    self.assertTrue("sg_myprecious_cut_order" in sg_shot)
+                    self.assertTrue("sg_myprecious_tail_out" in sg_shot)
+                    self.assertTrue("sg_myprecious_cut_in" in sg_shot)
+                    self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NO_CHANGE)
+                    self.assertEqual(clip_group.index, i + 1)
+                    # FIXME: fails with 1001 != 1000 (taken from tk-framework-editorial)
+                    # self.assertEqual(clip_group.head_in.to_frames(), self.sg_cut_items[i]["cut_item_in"] - 8)
+                    self.assertEqual(clip_group.cut_in.to_frames(), self.sg_cut_items[i]["cut_item_in"])
+                    self.assertEqual(clip_group.cut_out.to_frames(), self.sg_cut_items[i]["cut_item_out"])
+                    self.assertEqual(clip_group.tail_out.to_frames(), self.sg_cut_items[i]["cut_item_out"] + 8)
+                else:
+                    self.assertIsNone(clip_group.sg_shot)
+                    self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.NEW)
 
     def test_timecode_frame_mapping_modes(self):
         """


### PR DESCRIPTION
- added a `cache_shot_schema` method to SGShotFieldsConfig. Made sure it did preserve the schema between calls.
- in track_diff.TrackDiff, made sure it's initialized with `self._sg`
- Made `_get_matching_score` and `old_clip_for_shot` staticmethods.
- Added some unittests, updated some existing ones.
- Not sure what to do with all the EDLS only used in `test_read`, which should hopefully be covered by `otio`.