### PR TITLE
For #9389 add 2.7 and fix packaging issue in 2.7

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the SG Otio project
 
-name: Publish to TestPyPi
+name: Publish to TestPyPi and PyPI
 
 on:
   release:
@@ -16,7 +16,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     strategy:
       matrix:
-        python-version: ['3.10']  # Not sure if we should build for Python 2?
+        python-version: ["2.7", "3.10"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ which case the PATH should already be updated by the package manager.
 
 ### sg-otio package
 
-SG Otio can only be installed from sources at the moment.
+SG Otio can be installed from PyPi, e.g. `pip install sg-otio`
+
+SG Otio can also be installed from sources.
 - Get a local copy of this repo: `git clone https://github.com/GPLgithub/sg-otio.git`
 - Install it with `pip`: `pip install ./sg-otio`
 
@@ -61,6 +63,7 @@ sg-otio read --sg-site-url URL --session-token TOKEN --cut-id CUT_ID --file outp
 sg-otio read --sg-site-url URL --session-token TOKEN --cut-id CUT_ID --file output.xml --adapter-name fcp_xml
 sg-otio read --settings SETTINGS.JSON --sg-site-url URL --session-token TOKEN --cut-id CUT_ID --file output.xml --adapter-name fcp_xml
 ```
+
 ### Writing a Cut to SG
 Write a Video Track to SG as a Cut.
 Example:

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,7 @@ import subprocess
 import six
 
 with io.open("README.md", "r", encoding="utf-8") as f:
-    long_description = f.read()
-with io.open("LICENSE.txt", "r", encoding="utf-8") as f:
-    license = f.read().strip()
+    readme = f.read()
 
 
 def get_version():
@@ -53,9 +51,10 @@ setuptools.setup(
     author_email="pipelinesupport@gpltech.com",
     version=get_version(),
     description="A library for OpenTimelineIO integration with ShotGrid",
-    long_description=long_description,
     long_description_content_type="text/markdown",
-    license=license,
+    long_description=readme,
+    license="Apache License 2.0",
+    license_files=["LICENSE.txt"],
     url="https://github.com/GPLgithub/sg-otio.git",
     packages=setuptools.find_packages(),
     scripts=["bin/sg-otio"],


### PR DESCRIPTION
- Add python 2.7 when releasing to test pypi and pypi.
- Fix a problem when the full license text is passed as a license: https://github.com/pypa/twine/issues/454#issuecomment-464077386
- Tried to add the twine upload behavior for Azure packages, but I'm doing something wrong since even manually I can't upload the package (authentication refused).
