### PR TITLE
For #9812: Compute head in bug in automatic mode

### DIFF
--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -756,6 +756,7 @@ class SGCutClip(object):
             head_duration = RationalTime(sg_settings.default_head_duration, self._frame_rate)
             if sg_settings.timecode_in_to_frame_mapping_mode == _TC2FRAME_AUTOMATIC_MODE:
                 head_in = RationalTime(sg_settings.default_head_in, self._frame_rate)
+                head_duration = cut_in - head_in
             else:
                 head_in = cut_in - head_duration
         else:

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -387,8 +387,20 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip.tail_in.to_frames(), 20000 + 9 + 1)
         self.assertEqual(clip.tail_out.to_frames(), clip.tail_in.to_frames() + sg_settings.default_tail_duration - 1)
 
-        # Kevin: sg_settings.timecode_in_to_frame_mapping_mode = _TC2FRAME_AUTOMATIC_MODE
-        # Value from a SG Cut Item should be used as a base for an offset
+        # Switch to AUTOMATIC mode, and make sure the values are recomputed
+        # correctly. Do not set a cut item for now.
+        sg_settings.timecode_in_to_frame_mapping_mode = _TC2FRAME_AUTOMATIC_MODE
+        clip.sg_shot = None  # Unsetting the Shot forces a recompute
+        self.assertEqual(clip.compute_cut_in().to_frames(), 1009)
+        self.assertEqual(clip.head_in.to_frames(), 1001)
+        self.assertEqual(clip.head_duration.to_frames(), sg_settings.default_head_duration)
+        self.assertEqual(clip.cut_in.to_frames(), 1009)
+        self.assertEqual(clip.cut_out.to_frames(), 1018)
+        self.assertEqual(clip.tail_in.to_frames(), 1018 + 1)
+        self.assertEqual(clip.tail_out.to_frames(), clip.tail_in.to_frames() + sg_settings.default_tail_duration - 1)
+
+        # Again in AUTOMATIC mode, but this time with an SG cut item
+        # The value from it should be used as a base for an offset
         clip.metadata["sg"] = {
             "type": "CutItem",
             "id": -1,
@@ -399,8 +411,9 @@ class TestCutClip(unittest.TestCase):
         clip.sg_shot = None  # Unsetting the Shot forces a recompute
         # The clip timecode in is "00:00:00:00", so the cut in will be 3002 - 2
         self.assertEqual(clip.compute_cut_in().to_frames(), 3000)
-        self.assertEqual(clip.head_in.to_frames(), 3000 - 8)  # Kevin: AssertionError: 1001 != 2992
-        self.assertEqual(clip.head_duration.to_frames(), sg_settings.default_head_duration)
+        # The head in should be the default head in
+        self.assertEqual(clip.head_in.to_frames(), sg_settings.default_head_in)
+        self.assertEqual(clip.head_duration, clip.cut_in - clip.head_in)
         self.assertEqual(clip.cut_in.to_frames(), 3000)
         self.assertEqual(clip.cut_out.to_frames(), 3000 + 9)
         self.assertEqual(clip.tail_in.to_frames(), 3000 + 9 + 1)

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -390,13 +390,15 @@ class TestCutClip(unittest.TestCase):
         # Switch to AUTOMATIC mode, and make sure the values are recomputed
         # correctly. Do not set a cut item for now.
         sg_settings.timecode_in_to_frame_mapping_mode = _TC2FRAME_AUTOMATIC_MODE
+        sg_settings.default_head_duration = 54
+        sg_settings.default_head_in = 123
         clip.sg_shot = None  # Unsetting the Shot forces a recompute
-        self.assertEqual(clip.compute_cut_in().to_frames(), 1009)
-        self.assertEqual(clip.head_in.to_frames(), 1001)
+        self.assertEqual(clip.head_in.to_frames(), clip.head_in.to_frames())
+        self.assertEqual(clip.compute_cut_in().to_frames(), clip.head_in.to_frames() + sg_settings.default_head_duration)
         self.assertEqual(clip.head_duration.to_frames(), sg_settings.default_head_duration)
-        self.assertEqual(clip.cut_in.to_frames(), 1009)
-        self.assertEqual(clip.cut_out.to_frames(), 1018)
-        self.assertEqual(clip.tail_in.to_frames(), 1018 + 1)
+        self.assertEqual(clip.cut_in.to_frames(), clip.head_in.to_frames() + sg_settings.default_head_duration)
+        self.assertEqual(clip.cut_out.to_frames(), clip.cut_in.to_frames() + clip.duration().to_frames() - 1)
+        self.assertEqual(clip.tail_in.to_frames(), clip.cut_out.to_frames() + 1)
         self.assertEqual(clip.tail_out.to_frames(), clip.tail_in.to_frames() + sg_settings.default_tail_duration - 1)
 
         # Again in AUTOMATIC mode, but this time with an SG cut item


### PR DESCRIPTION
Based on what we discussed, in AUTOMATIC MODE:
- If the cut in is provided by SG, that should be its value.
- The head in is the default head in
- The head duration is cut_in - head_in

Changed the code and modified the tests accordingly.