### PR TITLE
For #9388, added active_count property

### DIFF
--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -313,7 +313,7 @@ class SGTrackDiff(object):
         self._sg_entity = None
         self._sg_shot_link_field_name = None
         self._counts = defaultdict(int)
-        self._total_count = 0
+        self._active_count = 0
         # We need to keep references on the tracks otherwise underlying C++ objects
         # might be freed.
         self._old_track = old_track
@@ -537,6 +537,17 @@ class SGTrackDiff(object):
                   instances.
         """
         return self._diffs_by_shots
+
+    @property
+    def active_count(self):
+        """
+        Return the number of clips from the current track.
+
+        :returns: A dictionary.
+        """
+        # Note: we could simply return len(self._new_track) here
+        # instead of keeping this count internally.
+        return self._active_count
 
     @property
     def counts(self):
@@ -924,7 +935,7 @@ class SGTrackDiff(object):
         """
         # Use a defaultdict so we don't have to worry about key existence
         self._counts = defaultdict(int)
-        self._total_count = 0
+        self._active_count = 0
         for shot_name, clip_group in self._diffs_by_shots.items():
             _, _, _, _, _, _, shot_diff_type = clip_group.get_shot_values()
             if shot_diff_type in _PER_SHOT_TYPE_COUNTS:
@@ -932,7 +943,7 @@ class SGTrackDiff(object):
                 self._counts[shot_diff_type] += 1
                 # We don't want to include omitted entries in our total
                 if shot_diff_type != _DIFF_TYPES.OMITTED:
-                    self._total_count += 1
+                    self._active_count += 1
             else:
                 # We count others per entries
                 for cut_diff in clip_group:
@@ -946,7 +957,7 @@ class SGTrackDiff(object):
                         _DIFF_TYPES.OMITTED_IN_CUT,
                         _DIFF_TYPES.OMITTED
                     ]:
-                        self._total_count += 1
+                        self._active_count += 1
         logger.debug("%s" % self._counts)
 
     def _retrieve_sg_link_from_sg_cuts(self):

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -1062,7 +1062,7 @@ class TestCutDiff(SGBaseTest):
         timeline_from_edl = otio.adapters.read_from_file(path)
         new_track = timeline_from_edl.tracks[0]
         track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
-
+        self.assertEqual(len(new_track), track_diff.active_count)
         # 4 shots exist in the DB, from shot_6666 to shot_6669
         self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
         self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
@@ -1105,6 +1105,7 @@ class TestCutDiff(SGBaseTest):
             track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
             self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NO_CHANGE), 4)
             self.assertEqual(track_diff.count_for_type(_DIFF_TYPES.NEW), 28)
+            self.assertEqual(len(new_track), track_diff.active_count)
 
             # Check the custom fields were queried
             expected = [x % "myprecious" for x in _ALT_SHOT_FIELDS]
@@ -1152,6 +1153,7 @@ class TestCutDiff(SGBaseTest):
         timeline_from_edl = otio.adapters.read_from_file(path)
         new_track = timeline_from_edl.tracks[0]
         track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        self.assertEqual(len(new_track), track_diff.active_count)
         for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
             self.assertEqual(1009, cut_diff.cut_in.to_frames())
 
@@ -1161,6 +1163,7 @@ class TestCutDiff(SGBaseTest):
             100,
         )
         track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        self.assertEqual(len(new_track), track_diff.active_count)
         for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
             self.assertEqual(
                 cut_diff.source_in.to_frames() - 10 + 100,
@@ -1168,6 +1171,7 @@ class TestCutDiff(SGBaseTest):
             )
         SGSettings().timecode_in_to_frame_mapping_mode = _TC2FRAME_ABSOLUTE_MODE
         track_diff = self._get_track_diff(new_track, mock_compute_clip_shot_name=self._mock_compute_clip_shot_name)
+        self.assertEqual(len(new_track), track_diff.active_count)
         for cut_diff in track_diff.diffs_for_type(_DIFF_TYPES.NEW):
             self.assertEqual(
                 cut_diff.source_in.to_frames(),


### PR DESCRIPTION
Added an `active_count` property to `TrackDiff` and tests for it.

_Note: We could discard the `_active_count` member and simply return the length of the new track, as checked by the unit tests. Not sure what is better_