### PR TITLE
9878 Fixes for old cut values

### DIFF
--- a/sg_otio/cut_diff.py
+++ b/sg_otio/cut_diff.py
@@ -194,10 +194,13 @@ class SGCutDiff(SGCutClip):
 
         :returns: A :class:`RationalTime` instance or ``None``.
         """
-        old_clip = self.old_clip
-        if old_clip:
-            return old_clip.head_duration
-        return None
+        sg_shot_head_in = self.sg_shot_head_in
+        if sg_shot_head_in is None:
+            return None
+        old_cut_in = self.old_cut_in
+        if old_cut_in is None:
+            return None
+        return old_cut_in - RationalTime(sg_shot_head_in, self._frame_rate)
 
     @property
     def old_tail_duration(self):
@@ -206,10 +209,13 @@ class SGCutDiff(SGCutClip):
 
         :returns: A :class:`RationalTime` instance or ``None``.
         """
-        old_clip = self.old_clip
-        if old_clip:
-            return old_clip.tail_duration
-        return None
+        sg_shot_tail_out = self.sg_shot_tail_out
+        if sg_shot_tail_out is None:
+            return None
+        old_cut_out = self.old_cut_out
+        if old_cut_out is None:
+            return None
+        return RationalTime(sg_shot_tail_out, self._frame_rate) - old_cut_out
 
     @property
     def cut_in(self):

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -939,7 +939,12 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.reasons, ["Head extended 1 frs", "Tail extended 1 frs"])
 
         # Check rescan are correctly detected.
+        # So far values coming from the Shot should be None
         self.assertIsNone(cut_diff.sg_shot_head_in)
+        self.assertIsNone(cut_diff.old_head_duration)
+        self.assertIsNone(cut_diff.sg_shot_tail_out)
+        self.assertIsNone(cut_diff.old_tail_duration)
+
         sg_shot["sg_head_in"] = 1001
         sg_shot["sg_tail_out"] = 1026
         self.assertEqual(cut_diff.sg_shot_head_in, 1001)
@@ -948,6 +953,9 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.head_in.to_frames(), 1001)
         self.assertEqual(cut_diff.cut_in.to_frames(), 1010)
         self.assertEqual(cut_diff.head_duration.to_frames(), 9)
+        self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
+        self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
+        self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
         # Within handles
         self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.CUT_CHANGE)
 
@@ -961,6 +969,9 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.sg_shot_head_in, 1001)
         self.assertEqual(cut_diff.cut_in.to_frames(), 1000)
         self.assertEqual(cut_diff.head_duration.to_frames(), -1)
+        self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
+        self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
+        self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
         self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
 
         # Same cut in, cut out after registered handles.
@@ -975,6 +986,9 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.cut_in.to_frames(), 1009)
         self.assertEqual(cut_diff.cut_out.to_frames(), 1009 + 19 - 1)
         self.assertEqual(cut_diff.tail_duration.to_frames(), - 1)
+        self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
+        self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
+        self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
         self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
 
         # Both cut in and cut out out of handle margins.
@@ -992,6 +1006,9 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.cut_in.to_frames(), 1000)
         self.assertEqual(cut_diff.cut_out.to_frames(), 1000 + 28 - 1)
         self.assertEqual(cut_diff.tail_duration.to_frames(), - 1)
+        self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
+        self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
+        self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
         self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
 
     def test_report(self):

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -1087,19 +1087,12 @@ class TestCutDiff(SGBaseTest):
         new_track = timeline_from_edl.tracks[0]
         # Check that using custom Shot cut fields is handled
         # Validation should fail
-        # Handle different names between Py 2.7 and 3
-        if hasattr(self, "assertRaisesRegex"):
-            with self.assertRaisesRegex(
-                ValueError,
-                "Following SG Shot fields are missing",
-            ):
-                self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
-        else:
-            with self.assertRaisesRegexp(
-                ValueError,
-                "Following SG Shot fields are missing",
-            ):
-                self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
+        with six.assertRaisesRegex(
+            self,
+            ValueError,
+            "Following SG Shot fields are missing",
+        ):
+            self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)
         # Bypass validation and check the fields are passed through
         with mock.patch.object(SGShotFieldsConfig, "validate_shot_cut_fields_prefix"):
             track_diff = self._get_track_diff(new_track, sg_track, self._mock_compute_clip_shot_name)

--- a/tests/test_media_cutter.py
+++ b/tests/test_media_cutter.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import unittest
+import six
 from distutils.spawn import find_executable
 
 try:
@@ -66,15 +67,9 @@ class TestMediaCutter(unittest.TestCase):
         ]
 
         with mock.patch("sg_otio.media_cutter.FFmpegExtractor.extract", side_effect=_mock_extract):
-            # Handle different names between Py 2.7 and 3
-            if hasattr(self, "assertRaisesRegex"):
-                # Since we're not generating any media we should get a RuntimeError.
-                with self.assertRaisesRegex(RuntimeError, r"^Failed to extract") as cm:
-                    media_cutter.cut_media_for_clips(max_workers=1)
-            else:
-                # Since we're not generating any media we should get a RuntimeError.
-                with self.assertRaisesRegexp(RuntimeError, r"^Failed to extract") as cm:
-                    media_cutter.cut_media_for_clips(max_workers=1)
+            # Since we're not generating any media we should get a RuntimeError.
+            with six.assertRaisesRegex(self, RuntimeError, r"^Failed to extract") as cm:
+                media_cutter.cut_media_for_clips(max_workers=1)
             # All files should be mentioned in the error message, not only the
             # one for which we faked a failure.
             for missing in media_cutter._media_filenames:

--- a/tests/test_media_uploader.py
+++ b/tests/test_media_uploader.py
@@ -70,15 +70,9 @@ class TestMediaUploader(SGBaseTest):
 #        ]
 #
 #        with mock.patch("sg_otio.media_cutter.FFmpegExtractor.extract", side_effect=_mock_extract):
-#            # Handle different names between Py 2.7 and 3
-#            if hasattr(self, "assertRaisesRegex"):
-#                # Since we're not generating any media we should get a RuntimeError.
-#                with self.assertRaisesRegex(RuntimeError, r"^Failed to extract") as cm:
-#                    media_cutter.cut_media_for_clips(max_workers=1)
-#            else:
-#                # Since we're not generating any media we should get a RuntimeError.
-#                with self.assertRaisesRegexp(RuntimeError, r"^Failed to extract") as cm:
-#                    media_cutter.cut_media_for_clips(max_workers=1)
+#            # Since we're not generating any media we should get a RuntimeError.
+#            with six.assertRaisesRegex(self, RuntimeError, r"^Failed to extract") as cm:
+#                media_cutter.cut_media_for_clips(max_workers=1)
 #            # All files should be mentioned in the error message, not only the
 #            # one for which we faked a failure.
 #            for missing in media_cutter._media_filenames:


### PR DESCRIPTION
Fixed code for getting old Cut values which should return a value only if they were set on the Shot, and added tests for it.
Fixed not all Shot fields being retrieved from SG for the CutItems, and added tests for it.
Generalised the use of `six.assertRaisesRegex` instead of checking the attributes.