### PR TITLE
8466 sg otio for Import Cut

### DIFF
--- a/sg_otio/clip_group.py
+++ b/sg_otio/clip_group.py
@@ -6,7 +6,7 @@ import logging
 from opentimelineio.opentime import RationalTime
 
 from .cut_clip import SGCutClip
-from .sg_settings import SGSettings
+from .sg_settings import SGShotFieldsConfig, SGSettings
 from .utils import compute_clip_shot_name
 
 logger = logging.getLogger(__name__)
@@ -210,7 +210,11 @@ class ClipGroup(object):
         self._reinstated_sg_shot = False
         omitted_statuses = SGSettings().reinstate_shot_if_status_is
         if self._sg_shot and omitted_statuses:
-            sg_status_list = self._sg_shot.get("sg_status_list")
+            config = SGShotFieldsConfig(
+                None, None
+            )
+            status_field = config.status
+            sg_status_list = self._sg_shot.get(status_field)
             if sg_status_list and sg_status_list in omitted_statuses:
                 self._reinstated_sg_shot = True
 

--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -89,6 +89,9 @@ _VERSION_FIELDS = [
     "sg_last_frame",
     "sg_path_to_movie",
     "sg_uploaded_movie",
+    "entity",
+    "entity.Shot.code",
+    "entity.Shot.id",
 ]
 
 # Fields we need to retrieve on Published Files
@@ -105,7 +108,10 @@ _PUBLISHED_FILE_FIELDS = [
     "version.Version.code",
     "version.Version.sg_first_frame",
     "version.Version.sg_last_frame",
-    "version.Version.sg_path_to_movie"
+    "version.Version.sg_path_to_movie",
+    "version.Version.entity",
+    "version.Version.entity.Shot.code",
+    "version.Version.entity.Shot.id",
 ]
 
 # Shot field templates used for alternate Shot cut fields

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -746,7 +746,7 @@ class SGCutClip(object):
                 None, None
             )
             status_field = config.status
-            return self.sg_shot[status_field]
+            return self.sg_shot.get(status_field)
         return None
 
     def compute_head_tail_values(self):

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -52,12 +52,12 @@ class SGCutClip(object):
             self._name = self._clip.metadata["cmx_3600"]["reel"]
         self._frame_rate = self._clip.duration().rate
         self._index = index
+        self._cut_item_name = self.name
         # Set the Shot, this will set the Shot name as well, if available.
         self.sg_shot = sg_shot
         if not self._shot_name:
             self._shot_name = compute_clip_shot_name(self._clip)
         self.compute_head_tail_values()
-        self._cut_item_name = self.name
 
     @property
     def clip(self):

--- a/sg_otio/sg_cut_reader.py
+++ b/sg_otio/sg_cut_reader.py
@@ -231,6 +231,9 @@ class SGCutReader(object):
             available_range=media_available_range,
         )
         clip.media_reference.name = name
+        for field in _PUBLISHED_FILE_FIELDS:
+            if field.startswith("version.Version"):
+                published_file["version"][field.replace("version.Version.", "")] = published_file[field]
         clip.media_reference.metadata["sg"] = published_file
 
     def add_media_references_from_sg(self, track, project):

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -805,7 +805,7 @@ class SGCutTrackWriter(object):
                     clip_group,
                     sg_project,
                     sg_linked_entity,
-                    sg_user
+                    sg_user,
                 )
                 sg_batch_data.append({
                     "request_type": "create",
@@ -866,9 +866,16 @@ class SGCutTrackWriter(object):
             if omit_status:
                 return {
                     "code": clip_group.name,
-                    "sg_status_list": omit_status
+                    sfg.status: omit_status
                 }
             return None
+
+        # Set the status even if we don't change it to get it
+        # back in SG batch result.
+        if clip_group.sg_shot:
+            shot_status = clip_group.sg_shot.get(sfg.status)
+        else:
+            shot_status = None
 
         shot_payload = {
             "project": sg_project,
@@ -878,9 +885,10 @@ class SGCutTrackWriter(object):
             sfg.cut_out: clip_group.cut_out.to_frames(),
             sfg.tail_out: clip_group.tail_out.to_frames(),
             sfg.cut_duration: clip_group.duration.to_frames(),
-            sfg.cut_order: clip_group.index
+            sfg.cut_order: clip_group.index,
+            sfg.status: shot_status,
         }
-        if sg_user:
+        if sg_user and not clip_group.sg_shot:  # Only settable on create
             shot_payload["created_by"] = sg_user
             shot_payload["updated_by"] = sg_user
         if sfg.working_duration:

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -177,7 +177,7 @@ class SGCutDiffGroup(ClipGroup):
         for cut_diff in self:
             if cut_diff.diff_type == _DIFF_TYPES.OMITTED:
                 return True
-            elif cut_diff.diff_type == _DIFF_TYPES.OMITTED_IN_CUT:
+            elif cut_diff.diff_type != _DIFF_TYPES.OMITTED_IN_CUT:
                 return False
         # If we reached that point it's because all entries are omitted in cut.
         return True

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -740,7 +740,7 @@ class SGTrackDiff(object):
         repeated = False
         if shot_key not in self._diffs_by_shots:
             self._diffs_by_shots[shot_key] = SGCutDiffGroup(
-                shot_key,
+                shot_name,
                 sg_shot=sg_shot
             )
         else:

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -334,7 +334,15 @@ class SGTrackDiff(object):
         # Retrieve the SG Entity we should use for the comparison
         # and do some sanity check
         if self._sg_entity:
-            if self._sg_entity["project"]["id"] != self._sg_project["id"]:
+            if self._sg_entity["type"] == "Project":
+                if self._sg_entity["id"] != self._sg_project["id"]:
+                    raise ValueError(
+                        "Invalid explicit SG Entity %s different from SG Project %s" % (
+                            self._sg_entity,
+                            self._sg_project
+                        )
+                    )
+            elif self._sg_entity["project"]["id"] != self._sg_project["id"]:
                 raise ValueError(
                     "Invalid explicit SG Entity %s not linked to SG Project %s" % (
                         self._sg_entity,

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -351,12 +351,13 @@ class SGTrackDiff(object):
                 )
 
         existing_sg_link = self._retrieve_sg_link_from_sg_cuts()
-        logger.warning("Existing link %s" % existing_sg_link)
         if not self._sg_entity:
             self._sg_entity = existing_sg_link
         elif existing_sg_link and existing_sg_link["type"] != "Project":
             # We only allow refining existing link from a Project to something
             # more specific.
+            # Arguably we could allow as well to generalise a Cut comparison
+            # to the Project.
             if (
                 self._sg_entity["type"] != existing_sg_link["type"]
                 or self._sg_entity["id"] != existing_sg_link["id"]

--- a/tests/resources/media_cutter.edl
+++ b/tests/resources/media_cutter.edl
@@ -1,0 +1,14 @@
+TITLE: Media cutter example
+000001 green_tape     V     C        00:00:00:00 00:00:00:16 01:00:00:00 01:00:00:16
+* FROM CLIP NAME: green_v01.mov
+000002 pink_tape      V     C        00:00:00:05 00:00:00:11 01:00:00:16 01:00:00:22
+* FROM CLIP NAME: purple_v01.mov
+000003 green_tape     V     C        00:00:00:05 00:00:00:16 01:00:00:22 01:00:01:09
+* FROM CLIP NAME: green_v01.mov
+000004 red_tape       V     C        00:00:00:12 00:00:01:00 01:00:01:09 01:00:01:21
+* FROM CLIP NAME: red_v01.mov
+000005 blue_tape      V     C        00:00:00:00 00:00:02:00 01:00:01:21 01:00:03:21
+* FROM CLIP NAME: blue_v01.mov
+000006 AAR0530        V     C        00:00:00:00 00:00:00:13 01:00:03:21 01:00:04:10
+* FROM CLIP NAME: red_v01.mov
+

--- a/tests/resources/media_cutter.edl
+++ b/tests/resources/media_cutter.edl
@@ -1,14 +1,7 @@
-TITLE: Media cutter example
+TITLE: Media cutter with no clip name
 000001 green_tape     V     C        00:00:00:00 00:00:00:16 01:00:00:00 01:00:00:16
-* FROM CLIP NAME: green_v01.mov
 000002 pink_tape      V     C        00:00:00:05 00:00:00:11 01:00:00:16 01:00:00:22
-* FROM CLIP NAME: purple_v01.mov
 000003 green_tape     V     C        00:00:00:05 00:00:00:16 01:00:00:22 01:00:01:09
-* FROM CLIP NAME: green_v01.mov
 000004 red_tape       V     C        00:00:00:12 00:00:01:00 01:00:01:09 01:00:01:21
-* FROM CLIP NAME: red_v01.mov
 000005 blue_tape      V     C        00:00:00:00 00:00:02:00 01:00:01:21 01:00:03:21
-* FROM CLIP NAME: blue_v01.mov
 000006 AAR0530        V     C        00:00:00:00 00:00:00:13 01:00:03:21 01:00:04:10
-* FROM CLIP NAME: red_v01.mov
-

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -1317,11 +1317,21 @@ class TestCutDiff(SGBaseTest):
         )
         timeline_from_edl = otio.adapters.read_from_file(path)
         edl_track = timeline_from_edl.tracks[0]
+        # No previous Cut information, no explicit SG Entity
+        # the Project should be used.
         track_diff = self._get_track_diff(
             edl_track,
             None,
             self._mock_compute_clip_shot_name,
             sg_entity=None
+        )
+        self.assertEqual(track_diff.sg_link, self.mock_project)
+        # We can explicitly set the Project if we want
+        track_diff = self._get_track_diff(
+            edl_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=self.mock_project
         )
         self.assertEqual(track_diff.sg_link, self.mock_project)
         track_diff = self._get_track_diff(
@@ -1369,6 +1379,18 @@ class TestCutDiff(SGBaseTest):
                 None,
                 self._mock_compute_clip_shot_name,
                 sg_entity=self.sg_sequences[1],
+            )
+        # Using an unexpected SG Project should raise an Exception
+        with six.assertRaisesRegex(
+            self,
+            ValueError,
+            r"Invalid explicit SG Entity .* different from SG Project"
+        ):
+            track_diff = self._get_track_diff(
+                sg_track,
+                None,
+                self._mock_compute_clip_shot_name,
+                sg_entity={"type": "Project", "id": 1234456},
             )
         # The SG link should be retrieved from the SG Cut track
         track_diff = self._get_track_diff(

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -69,6 +69,11 @@ class TestCutDiff(SGBaseTest):
             "project": self.mock_project,
             "type": "Sequence",
             "id": 6666,
+        }, {
+            "code": "seq_6667",
+            "project": self.mock_project,
+            "type": "Sequence",
+            "id": 6667,
         }]
         self.add_to_sg_mock_db(self.sg_sequences)
         self._sg_entities_to_delete.extend(self.sg_sequences)
@@ -184,7 +189,7 @@ class TestCutDiff(SGBaseTest):
         """
         return "shot_%d" % (6665 + list(clip.parent().each_clip()).index(clip) + 1)
 
-    def _get_track_diff(self, new_track, old_track=None, mock_compute_clip_shot_name=None):
+    def _get_track_diff(self, new_track, old_track=None, mock_compute_clip_shot_name=None, sg_entity=None):
         """
         Create a track diff altering the shot names so that there's
 
@@ -197,9 +202,9 @@ class TestCutDiff(SGBaseTest):
             if mock_compute_clip_shot_name:
                 with mock.patch("sg_otio.track_diff.compute_clip_shot_name", wraps=mock_compute_clip_shot_name):
                     with mock.patch("sg_otio.cut_clip.compute_clip_shot_name", wraps=mock_compute_clip_shot_name):
-                        return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track)
+                        return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track, sg_entity)
             else:
-                return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track)
+                return SGTrackDiff(self.mock_sg, self.mock_project, new_track, old_track, sg_entity)
 
     def tearDown(self):
         """
@@ -1298,3 +1303,107 @@ class TestCutDiff(SGBaseTest):
         del old_clip.media_reference.metadata["sg"]
         self.assertIsNone(cut_diff.sg_version)
         self.assertIsNone(cut_diff.sg_version_name)
+
+    def test_sg_link(self):
+        """
+        Test defining the SG link for TrackDiffs
+        """
+        self._add_sg_cut_data()
+        # Compare to Cut from EDL
+        path = os.path.join(
+            self.resources_dir,
+            "edls",
+            "R7v26.0_Turnover001_WiP_VFX__1_.edl"
+        )
+        timeline_from_edl = otio.adapters.read_from_file(path)
+        edl_track = timeline_from_edl.tracks[0]
+        track_diff = self._get_track_diff(
+            edl_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=None
+        )
+        self.assertEqual(track_diff.sg_link, self.mock_project)
+        track_diff = self._get_track_diff(
+            edl_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=self.sg_sequences[0]
+        )
+        self.assertEqual(track_diff.sg_link, self.sg_sequences[0])
+        with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+            mock_cut_url = get_read_url(
+                self.mock_sg.base_url,
+                self.sg_cuts[0]["id"],
+                self._SESSION_TOKEN
+            )
+            # Read it back from SG.
+            timeline_from_sg = otio.adapters.read_from_file(mock_cut_url, adapter_name="ShotGrid")
+            sg_track = timeline_from_sg.tracks[0]
+        # The SG link should be retrieved from the SG Cut track
+        track_diff = self._get_track_diff(
+            sg_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=None
+        )
+        self.assertEqual(track_diff.sg_link["type"], self.sg_sequences[0]["type"])
+        self.assertEqual(track_diff.sg_link["id"], self.sg_sequences[0]["id"])
+        # Using the expected SG link shouldn't cause problem
+        track_diff = self._get_track_diff(
+            sg_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=self.sg_sequences[0],
+        )
+        self.assertEqual(track_diff.sg_link["type"], self.sg_sequences[0]["type"])
+        self.assertEqual(track_diff.sg_link["id"], self.sg_sequences[0]["id"])
+        # Using an unexpected SG link should raise an Exception
+        with six.assertRaisesRegex(
+            self,
+            ValueError,
+            r"Invalid explicit SG Entity .* not matching existing link"
+        ):
+            track_diff = self._get_track_diff(
+                sg_track,
+                None,
+                self._mock_compute_clip_shot_name,
+                sg_entity=self.sg_sequences[1],
+            )
+        # The SG link should be retrieved from the SG Cut track
+        track_diff = self._get_track_diff(
+            edl_track,
+            sg_track,
+            self._mock_compute_clip_shot_name,
+            sg_entity=None
+        )
+        self.assertEqual(track_diff.sg_link["type"], self.sg_sequences[0]["type"])
+        self.assertEqual(track_diff.sg_link["id"], self.sg_sequences[0]["id"])
+        # Using the expected SG link shouldn't cause problem
+        track_diff = self._get_track_diff(
+            sg_track,
+            None,
+            self._mock_compute_clip_shot_name,
+            sg_entity=self.sg_sequences[0],
+        )
+        self.assertEqual(track_diff.sg_link["type"], self.sg_sequences[0]["type"])
+        self.assertEqual(track_diff.sg_link["id"], self.sg_sequences[0]["id"])
+        # If the previous Cut was linked to the Project, we should get it back
+        sg_track.metadata["sg"]["entity"] = self.mock_project
+        track_diff = self._get_track_diff(
+            edl_track,
+            sg_track,
+            self._mock_compute_clip_shot_name,
+            sg_entity=None
+        )
+        self.assertEqual(track_diff.sg_link, self.mock_project)
+        # If the previous Cut was linked to the Project, we should be able to refine
+        # the link with an Entity in the same Project
+        sg_track.metadata["sg"]["entity"] = self.mock_project
+        track_diff = self._get_track_diff(
+            edl_track,
+            sg_track,
+            self._mock_compute_clip_shot_name,
+            sg_entity=self.sg_sequences[1],
+        )
+        self.assertEqual(track_diff.sg_link, self.sg_sequences[1])


### PR DESCRIPTION
Fixed some problems discovered when trying to use the API.
Exposed some `SGCutTrackWrite`r methods which can be used from code already having a `SGTrackDiff`.
Ensured fields retrieved from PublishedFiles/Versions are always consistent on the Version.
Allowed the `sg_link` to be explicitly specified for `SGTrackDiff` and added tests for it.