### PR TITLE
For #10374 fixed bug for empty shots

### DIFF
--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -501,7 +501,7 @@ class SGCutTrackWriter(object):
             cut_item_payload[_EFFECTS_FIELD] = cut_clip.has_effects
 
         if cut_clip.has_retime:
-            description = "%s\nRetime: %s" % (description, self.retime_str)
+            description = "%s\nRetime: %s" % (description, cut_clip.retime_str)
         if _RETIME_FIELD in self.cut_item_schema:
             cut_item_payload[_RETIME_FIELD] = cut_clip.has_retime
 
@@ -797,7 +797,8 @@ class SGCutTrackWriter(object):
         sg_batch_data = []
         sg_shots = []
         for shot_name, clip_group in clips_by_shots.items():
-            if not shot_name:
+            # The shot name might be _no_shot_name, so we need to check the clip group name too.
+            if not shot_name or not clip_group.name:
                 continue
             if not clip_group.sg_shot:
                 logger.info("Creating Shot %s..." % clip_group.name)

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -839,11 +839,7 @@ class SGCutTrackWriter(object):
             # Update the clips Shots
             for sg_shot in sg_shots:
                 # clips_by_shots has the lowercased name as key.
-                clip_group = clips_by_shots.get(sg_shot["code"].lower())
-                if not clip_group:
-                    raise RuntimeError("No clip group for shot %s. Clip group shots: %s" % (
-                        sg_shot, clips_by_shots.keys()
-                    ))
+                clip_group = clips_by_shots[sg_shot["code"].lower()]
                 if not clip_group.sg_shot:
                     clip_group.sg_shot = sg_shot
                 else:

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -838,7 +838,12 @@ class SGCutTrackWriter(object):
             sg_shots = self._sg.batch(sg_batch_data)
             # Update the clips Shots
             for sg_shot in sg_shots:
-                clip_group = clips_by_shots[sg_shot["code"]]
+                # clips_by_shots has the lowercased name as key.
+                clip_group = clips_by_shots.get(sg_shot["code"].lower())
+                if not clip_group:
+                    raise RuntimeError("No clip group for shot %s. Clip group shots: %s" % (
+                        sg_shot, clips_by_shots.keys()
+                    ))
                 if not clip_group.sg_shot:
                     clip_group.sg_shot = sg_shot
                 else:


### PR DESCRIPTION
- We cannot rely on `shot_name` being empty since its value can be `_no_shot_name_XX`
- Another bug where we use `self.retime_str` instead of `cut_clip.retime_str`
- fixed another bug where we mix non-lowercase shot names with lowercase shot names.