### PR TITLE
For #10440: sg-otio binary bugfix.

### DIFF
--- a/bin/sg-otio.py
+++ b/bin/sg-otio.py
@@ -10,7 +10,7 @@ import opentimelineio as otio
 from shotgun_api3 import Shotgun
 
 from sg_otio.sg_settings import SGSettings
-from sg_otio.utils import get_write_url, get_read_url, add_media_references_from_sg
+from sg_otio.utils import get_write_url, get_read_url
 from sg_otio.media_cutter import MediaCutter
 from sg_otio.constants import _SG_OTIO_MANIFEST_PATH
 from sg_otio.track_diff import SGTrackDiff
@@ -220,14 +220,6 @@ def write_to_sg(args):
         if not os.path.isfile(args.movie):
             raise ValueError("%s does not exist" % args.movie)
     if SGSettings().create_missing_versions and args.movie:
-        sg = Shotgun(args.sg_site_url, session_token=session_token)
-        sg_entity = sg.find_one(args.entity_type, [["id", "is", args.entity_id]], ["project"])
-        # Add Media References to the clips with SG metadata about their Published File/Version
-        # if the clips match existing Entities in SG.
-        add_media_references_from_sg(timeline.video_tracks()[0], sg, sg_entity["project"])
-        # For Clips without Media References, extract the media from the movie,
-        # and add a Media Reference to the Clip.
-        # The write adapter will create a Version for each clip.
         media_cutter = MediaCutter(
             timeline,
             args.movie,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
     license_files=["LICENSE.txt"],
     url="https://github.com/GPLgithub/sg-otio.git",
     packages=setuptools.find_packages(),
-    scripts=["bin/sg-otio"],
+    scripts=["bin/sg-otio", "bin/sg-otio.py"],
     entry_points={
         "opentimelineio.plugins": "sg_otio = sg_otio"
     },


### PR DESCRIPTION
There were actually a couple of problems:
- The `bin/sg-otio.py` was not included in `setup.py`, which means it could not find the code to execute. Not sure why this used to work and doesn't anymore, but adding it to the `scripts` in `setup.py` seems to do the trick.
- The 'bin/sg-otio.py' file was not updated when `add_media_references_to_sg` became a responsibility of the `sg_cut_reader.py` here: https://github.com/GPLgithub/sg-otio/commit/d0cf5e63d0c9d335edc62a60e04065d5e4c96a38. This means that the code above `timeline = read_timeline_from_file(args)` already takes care of adding media references when reading from SG. Since then, we hadn't tested the binary. We should remember to test it in QA, even if the changes are about the Import Cut app.