### PR TITLE
For #10605: shot_reinstate_status_default setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This is what such file would contain with the default settings:
   "shot_cut_fields_prefix": null,
   "shot_omit_status": "omt",
   "shot_reinstate_status": "Previous Status",
+  "shot_reinstate_status_default": "act",
   "reinstate_shot_if_status_is": ["omt", "hld"]
 }
 ```
@@ -198,6 +199,9 @@ is one of the statuses set with the `reinstate_shot_if_status_is` setting.
 Their status will be set to the value set with the `shot_reinstate_status` setting, 
 unless it is the special "Previous Status" value. In this case the status they
 had before being omitted will be set.
+
+To determine the previous status, it relies on EventLogEntries, which means that if it can't find
+one (e.g. there were purged), it will use the value set with the `shot_reinstate_status_default` setting.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ unless it is the special "Previous Status" value. In this case the status they
 had before being omitted will be set.
 
 To determine the previous status, it relies on EventLogEntries, which means that if it can't find
-one (e.g. there were purged), it will use the value set with the `shot_reinstate_status_default` setting.
+one (e.g. they were purged), it will use the value set with the `shot_reinstate_status_default` setting.
 
 License
 -------

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -924,8 +924,10 @@ class SGCutTrackWriter(object):
 
         if clip_group.sg_shot_is_reinstated:
             reinstate_status = None
-            reinstate_status_pref = SGSettings().reinstate_shot_if_status_is
-            if reinstate_status_pref == _REINSTATE_FROM_PREVIOUS_STATUS:
+            settings = SGSettings()
+            shot_reinstate_status = settings.shot_reinstate_status
+            shot_reinstate_status_default = settings.shot_reinstate_status_default
+            if shot_reinstate_status == _REINSTATE_FROM_PREVIOUS_STATUS:
                 # Find the most recent status change event log entry where the
                 # project and linked Shot code match the current project/shot
                 filters = [
@@ -947,9 +949,12 @@ class SGCutTrackWriter(object):
                 # event log entry
                 if event_log:
                     reinstate_status = event_log["meta"]["old_value"]
-            elif reinstate_status_pref:
+                elif shot_reinstate_status_default:
+                    # Use the default status if we didn't find a previous status
+                    reinstate_status = shot_reinstate_status_default
+            elif shot_reinstate_status:
                 # Just use the status as is.
-                reinstate_status = reinstate_status_pref
+                reinstate_status = shot_reinstate_status
             # We set it even if we didn't found a valid status, which will unset
             # the status
             shot_payload[sfg.status] = reinstate_status

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -956,8 +956,7 @@ class SGCutTrackWriter(object):
                 # Just use the status as is.
                 reinstate_status = shot_reinstate_status
             if reinstate_status:
-                # We set it even if we didn't found a valid status, which will unset
-                # the status
+                # We set it only if we found a status to set.
                 shot_payload[sfg.status] = reinstate_status
             else:
                 logger.warning(

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -955,9 +955,16 @@ class SGCutTrackWriter(object):
             elif shot_reinstate_status:
                 # Just use the status as is.
                 reinstate_status = shot_reinstate_status
-            # We set it even if we didn't found a valid status, which will unset
-            # the status
-            shot_payload[sfg.status] = reinstate_status
+            if reinstate_status:
+                # We set it even if we didn't found a valid status, which will unset
+                # the status
+                shot_payload[sfg.status] = reinstate_status
+            else:
+                logger.warning(
+                    "Shot %s reinstated but no status to set found, leaving to current value %s" % (
+                        shot_payload["code"], shot_payload[sfg.status]
+                    )
+                )
 
         return shot_payload
 

--- a/sg_otio/sg_settings.py
+++ b/sg_otio/sg_settings.py
@@ -406,6 +406,34 @@ class SGSettings(Singleton("SGSettings", (object,), {})):
         """
         self._reinstate_shot_if_status_is = value or None
 
+    @property
+    def shot_reinstate_status_default(self):
+        """
+        Return the SG Shot status to use when reinstating Shots,
+        if shot_reinstate_status is set to _REINSTATE_FROM_PREVIOUS_STATUS.
+
+        Normally, when _REINSTATE_FROM_PREVIOUS_STATUS is set, the Shot is reinstated
+        from its previous status, but if there is no EventLogEntry for the Shot,
+        then this status is used instead.
+
+        :returns: A SG status short code or ``None``.
+        """
+        return self._shot_reinstate_status_default
+
+    @shot_reinstate_status_default.setter
+    def shot_reinstate_status_default(self, value):
+        """
+        Set the SG Shot status to use when reinstating Shots,
+        if shot_reinstate_status is set to _REINSTATE_FROM_PREVIOUS_STATUS.
+
+        Normally, when _REINSTATE_FROM_PREVIOUS_STATUS is set, the Shot is reinstated
+        from its previous status, but if there is no EventLogEntry for the Shot,
+        then this status is used instead.
+
+        :param value: A SG status short code or ``None``.
+        """
+        self._shot_reinstate_status_default = value or None
+
     def reset_to_defaults(self):
         """
         Reset settings to all default values.
@@ -427,6 +455,7 @@ class SGSettings(Singleton("SGSettings", (object,), {})):
         self._shot_cut_fields_prefix = None
         self._shot_omit_status = "omt"
         self._shot_reinstate_status = _REINSTATE_FROM_PREVIOUS_STATUS
+        self._shot_reinstate_status_default = "act"
         self._reinstate_shot_if_status_is = ["omt", "hld"]
 
 


### PR DESCRIPTION
- Added a new setting `shot_reinstate_status_default` with a default value of "act"
- if the value of `shot_reinstate_status` is `Previous Status`, and no EventLogEntry is found for the Shot, the default value, if set, is used.
- fixed a bug where we were not comparing the right setting so "Previous Status" was not working properly.