### PR TITLE
For #12419: fix compute clip shot name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     name: "sg-otio"
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-#          pip install six
           python -m pip install --upgrade pip
           pip install git+https://github.com/shotgunsoftware/python-api.git
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
+        os: [macos-latest] # windows-latest when wheel is in place
 
     runs-on: ${{ matrix.os }}
 
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install six
           python -m pip install --upgrade pip
           pip install git+https://github.com/shotgunsoftware/python-api.git
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,11 +54,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install six
           pip install git+https://github.com/shotgunsoftware/python-api.git
 
       - name: Install Package
         run: |
+          pip install six
           pip install -e .
           pip install -e .[dev]  # Why 2 pip installs?
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Install Package
         run: |
+          pip install -e .
           pip install -e .[dev]  # Why 2 pip installs?
 
       - name: Lint with flake8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,13 +53,12 @@ jobs:
 
       - name: Install dependencies
         run: |
+#          pip install six
           python -m pip install --upgrade pip
           pip install git+https://github.com/shotgunsoftware/python-api.git
 
       - name: Install Package
         run: |
-          pip install six
-          pip install -e .
           pip install -e .[dev]  # Why 2 pip installs?
 
       - name: Lint with flake8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: [macos-latest] # windows-latest when wheel is in place
+        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install six
           python -m pip install --upgrade pip
           pip install git+https://github.com/shotgunsoftware/python-api.git
 

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install dependencies
       run: >-
-        pip install six wheel
+        pip install wheel
     - name: Build
       run: >-
         python setup.py bdist_wheel

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     strategy:
       matrix:
-        python-version: ["2.7", "3.10"]
+        python-version: [ "3.10"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import io
 import setuptools
 import subprocess
-import six
 
 with io.open("README.md", "r", encoding="utf-8") as f:
     readme = f.read()
@@ -26,7 +25,7 @@ def get_version():
     # (e.g. pip install ./sg-otio), the version number
     # will be picked up from the most recently added tag.
     try:
-        version_git = six.ensure_str(
+        version_git = "%s" % (
             subprocess.check_output(
                 ["git", "describe", "--abbrev=0", "--tags"]
             ).rstrip()

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setuptools.setup(
     install_requires=[
         "OpenTimelineIO >= 0.12.0",
         "shotgun-api3 >= 3.3.3",
-        "six",
         "pathlib2; python_version < '3.4'",
         "futures; python_version < '3.2'",
     ],
@@ -78,7 +77,6 @@ setuptools.setup(
             "pytest",
             "pytest-cov",
             "twine",
-            "mock; python_version < '3.0.0'"
         ]
     },
     classifiers=[
@@ -88,8 +86,6 @@ setuptools.setup(
         "Topic :: Multimedia :: Video :: Display",
         "Topic :: Multimedia :: Video :: Non-Linear Editor",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,8 @@ def get_version():
     # If everything fails, return a sensible string highlighting that the version
     # couldn't be extracted. If a version is not specified in `setup`, 0.0.0
     # will be used by default, it seems better to have an explicit keyword for
-    # this case, following TK "dev" locator pattern and the convention described here:
-    # http://peak.telecommunity.com/DevCenter/setuptools#specifying-your-project-s-version
-    return "dev"
+    # this case, following PEP440
+    return "0.0.0.dev0"
 
 
 setuptools.setup(

--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -2,7 +2,7 @@
 # Copyright Contributors to the SG Otio project
 
 import logging
-from six.moves.urllib import parse
+from urllib import parse
 
 import opentimelineio as otio
 import shotgun_api3

--- a/sg_otio/utils.py
+++ b/sg_otio/utils.py
@@ -111,7 +111,7 @@ def compute_clip_shot_name(clip):
     shot_metadata = sg_metadata.get("shot", {}) or {}
     if shot_metadata.get("code"):
         return clip.metadata["sg"]["shot"]["code"]
-    if clip.markers:
+    if clip.markers and clip.markers[0].name:
         # TODO: we're only considering the first marker? Is that right?
         return clip.markers[0].name.split()[0]
     comment_match = None

--- a/sg_otio/utils.py
+++ b/sg_otio/utils.py
@@ -8,7 +8,7 @@ import re
 import string
 import sys
 
-from six.moves.urllib import parse
+from urllib import parse
 
 from .sg_settings import SGSettings
 

--- a/sg_otio/utils.py
+++ b/sg_otio/utils.py
@@ -111,9 +111,10 @@ def compute_clip_shot_name(clip):
     shot_metadata = sg_metadata.get("shot", {}) or {}
     if shot_metadata.get("code"):
         return clip.metadata["sg"]["shot"]["code"]
-    if clip.markers and clip.markers[0].name:
-        # TODO: we're only considering the first marker? Is that right?
-        return clip.markers[0].name.split()[0]
+    if clip.markers:
+        for marker in clip.markers:
+            if marker.name:
+                return marker.name.split()[0]
     comment_match = None
     if clip.metadata.get("cmx_3600") and clip.metadata["cmx_3600"].get("comments"):
         comments = clip.metadata["cmx_3600"]["comments"]

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -66,6 +66,8 @@ class TestCutClip(unittest.TestCase):
             * FROM CLIP NAME: clip_1
             * COMMENT: shot_002
             * shot_003
+            003  reel_name V     C        00:00:00:00 00:00:01:00 01:00:02:00 01:00:03:00
+            * LOC: 01:00:00:12 YELLOW   
         """
         timeline = otio.adapters.read_from_string(edl, adapter_name="cmx_3600")
         edl_clip = list(timeline.tracks[0].each_clip())[0]
@@ -116,6 +118,15 @@ class TestCutClip(unittest.TestCase):
         }
         clip._shot_name = compute_clip_shot_name(clip)
         self.assertEqual(clip.shot_name, "shot_from_SG")
+
+        # A locator with an empty name.
+        sg_settings.use_clip_names_for_shot_names = False
+        edl_clip = list(timeline.tracks[0].each_clip())[2]
+        clip = SGCutClip(
+            edl_clip
+        )
+        clip._shot_name = compute_clip_shot_name(clip)
+        self.assertIsNone(clip.shot_name)
 
     def test_clip_values(self):
         """

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -3,7 +3,6 @@
 
 import os
 import unittest
-import six
 
 import opentimelineio as otio
 from opentimelineio.opentime import TimeRange, RationalTime
@@ -182,8 +181,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip_1.retime_str, "LinearTimeWarp (time scalar: 2.0)")
         self.assertTrue(not clip_1.has_effects)
         self.assertEqual(clip_1.effects_str, "")
-        six.assertRegex(
-            self,
+        self.assertRegex(
             clip_1.source_info,
             r"001\s+reel_1\s+V\s+C\s+01:00:00:00 01:00:02:00 02:00:00:00 02:00:01:00"
         )
@@ -201,8 +199,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip_2.edit_out.to_frames(), 48)
         self.assertTrue(not clip_2.has_retime)
         self.assertEqual(clip_2.retime_str, "")
-        six.assertRegex(
-            self,
+        self.assertRegex(
             clip_2.source_info,
             r"002\s+reel_2\s+V\s+C\s+00:00:00:00 00:00:01:00 02:00:01:00 02:00:02:00"
         )

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -68,6 +68,9 @@ class TestCutClip(unittest.TestCase):
             * shot_003
             003  reel_name V     C        00:00:00:00 00:00:01:00 01:00:02:00 01:00:03:00
             * LOC: 01:00:00:12 YELLOW   
+            004  reel_name V     C        00:00:00:00 00:00:01:00 01:00:03:00 01:00:04:00
+            * LOC: 01:00:00:12 YELLOW   
+            * LOC: 01:00:00:12 YELLOW  shot_004
         """
         timeline = otio.adapters.read_from_string(edl, adapter_name="cmx_3600")
         edl_clip = list(timeline.tracks[0].each_clip())[0]
@@ -127,6 +130,14 @@ class TestCutClip(unittest.TestCase):
         )
         clip._shot_name = compute_clip_shot_name(clip)
         self.assertIsNone(clip.shot_name)
+
+        # Two locators, the first one has an empty name, the second one has a name.
+        edl_clip = list(timeline.tracks[0].each_clip())[3]
+        clip = SGCutClip(
+            edl_clip
+        )
+        clip._shot_name = compute_clip_shot_name(clip)
+        self.assertEqual(clip.shot_name, "shot_004")
 
     def test_clip_values(self):
         """

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -67,9 +67,9 @@ class TestCutClip(unittest.TestCase):
             * COMMENT: shot_002
             * shot_003
             003  reel_name V     C        00:00:00:00 00:00:01:00 01:00:02:00 01:00:03:00
-            * LOC: 01:00:00:12 YELLOW   
+            * LOC: 01:00:00:12 YELLOW
             004  reel_name V     C        00:00:00:00 00:00:01:00 01:00:03:00 01:00:04:00
-            * LOC: 01:00:00:12 YELLOW   
+            * LOC: 01:00:00:12 YELLOW
             * LOC: 01:00:00:12 YELLOW  shot_004
         """
         timeline = otio.adapters.read_from_string(edl, adapter_name="cmx_3600")

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -4,7 +4,6 @@
 import copy
 import logging
 import os
-import six
 
 import shotgun_api3
 
@@ -228,8 +227,7 @@ class TestCutDiff(SGBaseTest):
             ),
         )
         # Omitted Clips need to be linked to a SG CutItem
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             "Omitted Clips need to be linked to a SG CutItem"
         ):
@@ -246,8 +244,7 @@ class TestCutDiff(SGBaseTest):
             sg_shot=None,
         )
         # We can only compare to Clips linked to a SG CutItem
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             "Old clips for SGCutDiff must be coming from a SG Cut Item"
         ):
@@ -297,8 +294,7 @@ class TestCutDiff(SGBaseTest):
             sg_shot=sg_shots[1],
         )
         # Shot mismatches should raise an error
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             "Shot mismatch between current clip and old one 2 vs 1"
         ):
@@ -1109,8 +1105,7 @@ class TestCutDiff(SGBaseTest):
         new_track = timeline_from_edl.tracks[0]
         # Check that using custom Shot cut fields is handled
         # Validation should fail
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             "Following SG Shot fields are missing",
         ):
@@ -1369,8 +1364,7 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(track_diff.sg_link["type"], self.sg_sequences[0]["type"])
         self.assertEqual(track_diff.sg_link["id"], self.sg_sequences[0]["id"])
         # Using an unexpected SG link should raise an Exception
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             r"Invalid explicit SG Entity .* not matching existing link"
         ):
@@ -1381,8 +1375,7 @@ class TestCutDiff(SGBaseTest):
                 sg_entity=self.sg_sequences[1],
             )
         # Using an unexpected SG Project should raise an Exception
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             ValueError,
             r"Invalid explicit SG Entity .* different from SG Project"
         ):

--- a/tests/test_media_cutter.py
+++ b/tests/test_media_cutter.py
@@ -6,7 +6,6 @@ import logging
 import os
 import subprocess
 import unittest
-import six
 from distutils.spawn import find_executable
 
 try:
@@ -68,7 +67,7 @@ class TestMediaCutter(unittest.TestCase):
 
         with mock.patch("sg_otio.media_cutter.FFmpegExtractor.extract", side_effect=_mock_extract):
             # Since we're not generating any media we should get a RuntimeError.
-            with six.assertRaisesRegex(self, RuntimeError, r"^Failed to extract") as cm:
+            with self.assertRaisesRegex(RuntimeError, r"^Failed to extract") as cm:
                 media_cutter.cut_media_for_clips(max_workers=1)
             # All files should be mentioned in the error message, not only the
             # one for which we faked a failure.


### PR DESCRIPTION
When trying to find a name from a marker, we take the first part of the name.
The problem is that the name is sometimes empty in an EDL, e.g.

```
*LOC: 01:03:29:04 CYAN 
```

this causes sg-otio to crash

Instead, get it from the loc if possible.

Note that I tried to see if in some cases there were other interesting markers but no, taking the first marker is still a good bet.

Also note that this EDL is problematic to say the least, because some markers will have names for Shots that are bizarre, for example:

```
*LOC: 01:13:07:01 MAGENTA STABILIZE  # Shot name becomes stabilize

*LOC: 01:12:25:13 MAGENTA 100-103-100% DYNAMIC RESIZE  # shot name becomes 100-103-100%

*LOC: 01:12:18:17 MAGENTA 115-118% DYN AMIC RESIZE  #  shot name becomes 115-118%
```