### PR TITLE
For #9944: Fix get_shot_payload slowness

### DIFF
--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -1019,7 +1019,11 @@ class SGCutTrackWriter(object):
                 entity_type,
                 [["id", "is", entity_id]],
                 # We might need the absolute cut order of the linked entity later, it's better
-                # to retrieve it now.
+                # to retrieve it now. We should normally get the field from sfg.absolute_cut_order,
+                # but to get the Shot Fields Config, we need the linked entity, so to query it properly,
+                # we'd need to retrieve the linked entity twice.
+                # Instead, we just get the field from the constant instead, if it doesn't exist, it'll just
+                # not be present in the payload.
                 ["project", "code", _ABSOLUTE_CUT_ORDER_FIELD]
             )
             if not sg_linked_entity:

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -806,7 +806,7 @@ class SGCutTrackWriter(object):
                     clip_group,
                     sg_project,
                     sg_linked_entity,
-                    sg_user
+                    sg_user,
                 )
                 sg_batch_data.append({
                     "request_type": "create",

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -820,7 +820,7 @@ class SGCutTrackWriter(object):
                     clip_group,
                     sg_project,
                     sg_linked_entity,
-                    sg_user,
+                    sg_user
                 )
                 if shot_payload:
                     sg_batch_data.append({


### PR DESCRIPTION
get_shot_payload, when the settings ask for an absolute cut order, does the same request over and over again to get the `sg_absolute_cut_order` field of the linked entity.

Instead, check if it's necessary to get the `entity_cut_order` upfront, and pass it to the `_get_shot_payload` as a parameter.


Note that there's another request that can be made if a shot is reinstated and the setting is set to "reinstate from previous status", but this seems like it shouldn't affect too many shots in a timeline.