### PR TITLE
For #12752, respect case from EDL

### DIFF
--- a/sg_otio/clip_group.py
+++ b/sg_otio/clip_group.py
@@ -470,13 +470,15 @@ class ClipGroup(object):
         shots_by_name = {}
         for i, clip in enumerate(video_track.each_clip()):
             shot_name = compute_clip_shot_name(clip)
+            shot_key = ""
             if shot_name:
                 # Matching Shots must be case insensitive
-                shot_name = shot_name.lower()
+                shot_key = shot_name.lower()
             # Ensure a ClipGroup and add SGCutClip to it.
-            if shot_name not in shots_by_name:
-                shots_by_name[shot_name] = ClipGroup(shot_name)
-            shots_by_name[shot_name].add_clip(
+            if shot_key not in shots_by_name:
+                # Preserve the shot name for the group
+                shots_by_name[shot_key] = ClipGroup(shot_name)
+            shots_by_name[shot_key].add_clip(
                 SGCutClip(clip, index=i + 1, sg_shot=None)
             )
         return shots_by_name

--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -125,9 +125,9 @@ class SGCutTrackWriter(object):
             shot_names = []
             seen_names = []
             duplicate_names = {}
-            for shot, clip_group in clips_by_shots.items():
-                if shot:
-                    shot_names.append(shot)
+            for shot_key, clip_group in clips_by_shots.items():
+                if shot_key:
+                    shot_names.append(shot_key)
                 for clip in clip_group.clips:
                     if clip.name not in seen_names:
                         seen_names.append(clip.name)
@@ -143,6 +143,8 @@ class SGCutTrackWriter(object):
                     clip_name_index += 1
 
             if shot_names:
+                # find is case insensitive so we can use our
+                # lowered case shot keys.
                 sg_shots = self._sg.find(
                     "Shot",
                     [["project", "is", sg_project], ["code", "in", shot_names]],
@@ -365,9 +367,9 @@ class SGCutTrackWriter(object):
         cut_item_clips = []
 
         # Loop over all clips
-        for shot_name, clip_group in clips_by_shots.items():
+        for shot_key, clip_group in clips_by_shots.items():
             if clip_group.sg_shot_is_omitted:
-                logger.info("Skipping omitted Shot %s" % shot_name)
+                logger.info("Skipping omitted Shot %s" % shot_key)
                 continue
             for clip in clip_group.clips:
                 logger.debug("Getting payload for %s %s %s %s %s" % (
@@ -797,9 +799,9 @@ class SGCutTrackWriter(object):
         """
         sg_batch_data = []
         sg_shots = []
-        for shot_name, clip_group in clips_by_shots.items():
-            # The shot name might be _no_shot_name, so we need to check the clip group name too.
-            if not shot_name or not clip_group.name:
+        for shot_key, clip_group in clips_by_shots.items():
+            # The shot key might be _no_shot_name, so we need to check the clip group name too.
+            if not shot_key or not clip_group.name:
                 continue
             if not clip_group.sg_shot:
                 logger.info("Creating Shot %s..." % clip_group.name)

--- a/tests/test_clip_group.py
+++ b/tests/test_clip_group.py
@@ -32,7 +32,7 @@ class TestClipGroup(unittest.TestCase):
 
             001  clip_1 V     C        01:00:01:00 01:00:10:00 01:00:00:00 01:00:09:00
             * FROM CLIP NAME: shot_001_v001
-            * COMMENT: shot_001
+            * COMMENT: SHOT_001
             002  clip_2 V     C        01:00:02:00 01:00:05:00 01:00:09:00 01:00:12:00
             * FROM CLIP NAME: shot_002_v001
             * COMMENT: shot_002
@@ -41,7 +41,7 @@ class TestClipGroup(unittest.TestCase):
             * COMMENT: shot_001
             004  clip_4 V     C        01:00:00:00 01:00:01:00 01:00:16:00 01:00:17:00
             * FROM CLIP NAME: shot_002_v001
-            * COMMENT: shot_002
+            * COMMENT: SHOT_002
             005  clip_5 V     C        01:00:00:00 01:00:01:00 01:00:17:00 01:00:18:00
             * FROM CLIP NAME: shot_003_v001
             * COMMENT: shot_003
@@ -52,10 +52,13 @@ class TestClipGroup(unittest.TestCase):
         shot_groups = ClipGroup.groups_from_track(track)
         self.assertEqual(set(shot_groups.keys()), {"shot_001", "shot_002", "shot_003"})
         self.assertIsNone(shot_groups["shot_001"].sg_shot)
+        self.assertEqual(shot_groups["shot_001"].name, "SHOT_001")  # First entry is upper case
         shot_001_clips = shot_groups["shot_001"].clips
         self.assertEqual({clip.name for clip in shot_001_clips}, {"clip_1", "clip_3"})
+        self.assertEqual(shot_groups["shot_002"].name, "shot_002")  # First entry is lower case
         shot_002_clips = shot_groups["shot_002"].clips
         self.assertEqual({clip.name for clip in shot_002_clips}, {"clip_2", "clip_4"})
+        self.assertEqual(shot_groups["shot_003"].name, "shot_003")  # Single entry is lower case
         shot_003_clips = shot_groups["shot_003"].clips
         self.assertEqual({clip.name for clip in shot_003_clips}, {"clip_5"})
 
@@ -126,7 +129,7 @@ class TestClipGroup(unittest.TestCase):
             shot_groups = ClipGroup.groups_from_track(track)
 
             shot = shot_groups["shot_001"]
-            # Matching Shots is case insensitive
+            # The case is taken from the first entry
             self.assertEqual(shot.name, "shot_001")
             self.assertEqual(shot.index, 3)  # first clip is the last starting at 01:00:00:00
             self.assertEqual(shot.cut_in.to_frames(), head_in + head_duration)

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -162,7 +162,7 @@ class ShotgridAdapterTest(SGBaseTest):
         """
         Override compute clip shot name to get a unique shot name per clip.
         """
-        return "shot_%d" % (6665 + list(clip.parent().each_clip()).index(clip) + 1)
+        return "Shot_%d" % (6665 + list(clip.parent().each_clip()).index(clip) + 1)
 
     def test_read(self):
         """
@@ -638,6 +638,9 @@ class ShotgridAdapterTest(SGBaseTest):
                     ["code"],
                 )
                 self.assertEqual(len(sg_shots), 6)
+                # Name case should have been preserved
+                for sg_shot in sg_shots:
+                    self.assertTrue(sg_shot["code"].startswith("Shot_"))
                 # We should have Versions created linked to Shots
                 sg_versions = self.mock_sg.find(
                     "Version",
@@ -803,13 +806,13 @@ class ShotgridAdapterTest(SGBaseTest):
 
             001  clip_1 V     C        01:00:01:00 01:00:10:00 01:00:00:00 01:00:09:00
             * FROM CLIP NAME: shot_001_v001
-            * COMMENT: test_write_shot_shot_001
+            * COMMENT: test_write_shot_SHOT_001
             002  clip_2 V     C        01:00:02:00 01:00:05:00 01:00:09:00 01:00:12:00
             * FROM CLIP NAME: shot_002_v001
             * COMMENT: test_write_shot_shot_002
             003  clip_3 V     C        01:00:00:00 01:00:04:00 01:00:12:00 01:00:16:00
             * FROM CLIP NAME: shot_001_v001
-            * COMMENT: test_write_shot_SHOT_001
+            * COMMENT: test_write_shot_shot_001
         """
         timeline = otio.adapters.read_from_string(edl, adapter_name="cmx_3600")
         track = timeline.tracks[0]
@@ -818,12 +821,15 @@ class ShotgridAdapterTest(SGBaseTest):
             clip = track[0]
             self.assertEqual(clip.metadata["sg"]["cut_order"], 1)
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1033)
+            self.assertEqual(clip.metadata["sg"]["shot"]["code"], "test_write_shot_SHOT_001")
             clip = track[1]
             self.assertEqual(clip.metadata["sg"]["cut_order"], 2)
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1009)
             clip = track[2]
             self.assertEqual(clip.metadata["sg"]["cut_order"], 3)
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1009)
+            # Shot name case taken from first entry
+            self.assertEqual(clip.metadata["sg"]["shot"]["code"], "test_write_shot_SHOT_001")
 
             mock_cut_url = get_read_url(
                 self.mock_sg.base_url,
@@ -835,10 +841,12 @@ class ShotgridAdapterTest(SGBaseTest):
             sg_track = timeline_from_sg.tracks[0]
             clip = sg_track[0]
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1033)
+            self.assertEqual(clip.metadata["sg"]["shot"]["code"], "test_write_shot_SHOT_001")
             clip = sg_track[1]
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1009)
             clip = sg_track[2]
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1009)
+            self.assertEqual(clip.metadata["sg"]["shot"]["code"], "test_write_shot_SHOT_001")
 
     def test_read_shot_fields(self):
         """


### PR DESCRIPTION
Ensured that the case for Shot names retrieved from the EDL is respected and mix of lower and upper case names for the same Shot don't cause duplicates.
- Clarified the code a bit by using `shot_key` instead of `shot_name` in a couple of places.
- Added tests for upper and lower case Shot names.