### PR TITLE
For #13116, fix and tests

### DIFF
--- a/bin/sg-otio.py
+++ b/bin/sg-otio.py
@@ -6,14 +6,9 @@ import argparse
 import logging
 import os
 
-import opentimelineio as otio
 from shotgun_api3 import Shotgun
 
-from sg_otio.sg_settings import SGSettings
-from sg_otio.utils import get_write_url, get_read_url
-from sg_otio.media_cutter import MediaCutter
 from sg_otio.constants import _SG_OTIO_MANIFEST_PATH
-from sg_otio.track_diff import SGTrackDiff
 from sg_otio.command import SGOtioCommand
 
 logging.basicConfig(level=logging.INFO)
@@ -145,7 +140,7 @@ def run():
             adapter_name=args.adapter,
             frame_rate=args.frame_rate,
             settings=args.settings,
-            movie=arggs.movie,
+            movie=args.movie,
         )
     elif args.command == "compare":
         command.compare_to_sg(
@@ -155,6 +150,7 @@ def run():
             frame_rate=args.frame_rate,
             write=args.write,
         )
+
 
 def add_common_args(parser):
     """
@@ -235,6 +231,7 @@ def _get_sg_handle(args):
     elif args.script_name and args.api_key:
         return Shotgun(args.sg_site_url, script_name=args.script_name, api_key=args.api_key)
     raise ValueError("Unable to connect to SG from %s" % args)
+
 
 if __name__ == "__main__":
     run()

--- a/sg_otio/__init__.py
+++ b/sg_otio/__init__.py
@@ -1,2 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the SG Otio project
+
+# Workaround until https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1705
+# is approved and merged
+import json
+from opentimelineio.core._core_utils import AnyDictionary
+from opentimelineio.core import add_method, _value_to_any, _serialize_json_to_string
+
+
+@add_method(AnyDictionary)  # noqa: F811
+def to_dict(self):  # noqa: F811
+    """
+    Convert to a built-in dict. It will recursively convert all values
+    to their corresponding python built-in types.
+    """
+    return json.loads(_serialize_json_to_string(_value_to_any(self), {}, 0))

--- a/sg_otio/command.py
+++ b/sg_otio/command.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the SG Otio project
+
+import logging
+import os
+
+import opentimelineio as otio
+
+from .sg_settings import SGSettings
+from .utils import get_write_url, get_read_url
+from .media_cutter import MediaCutter
+from .track_diff import SGTrackDiff
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("sg-otio")
+
+
+class SGOtioCommand(object):
+    """
+    A class to run SGOtio commands.
+    """
+    def __init__(self, sg, verbose=False):
+        """
+        Instantiate a new :class:`SGOtioCommand`.
+
+        :param sg: A connected SG handle.
+        """
+        self._sg = sg
+        self._sg_session_token = self._sg.get_session_token()
+        if verbose:
+            logger.setLevel(logging.DEBUG)
+        else:
+            logger.setLevel(logging.INFO)
+
+    def read_from_sg(self, sg_cut_id, file_path=None, adapter_name=None, frame_rate=24):
+        """
+        Reads information from a Cut in ShotGrid and print it
+        to stdout, or write it to a file.
+
+        If printed to stdout, the output is in OTIO format.
+        If written to a file, the output depends on the extension of the file
+        or the adapter chosen.
+
+        The retrieved SG entities are stored in the items metadata.
+
+        :param sg_cut_id: A SG Cut id.
+        :param str file_path: Optional file path to write to.
+        :param str adapter_name: Optional otio adapter name, e.g. cmx_3600.
+        :param float frame_rate: Optional frame rate to use when reading the file.
+        """
+        url = get_read_url(
+            sg_site_url=self._sg.base_url,
+            cut_id=sg_cut_id,
+            session_token=self._sg_session_token
+        )
+        timeline = otio.adapters.read_from_file(
+            url,
+            adapter_name="ShotGrid",
+        )
+        if not file_path:
+            if adapter_name:
+                # It seems otio write_to_string choke on unset adapter?
+                logger.info(otio.adapters.write_to_string(timeline, adapter_name=adapter_name))
+            else:
+                logger.info(otio.adapters.write_to_string(timeline))
+        else:
+            _, ext = os.path.splitext(file_path)
+            if (ext and ext.lower() == ".edl") or adapter_name == "cmx_3600":
+                otio.adapters.write_to_file(
+                    timeline,
+                    file_path,
+                    adapter_name=adapter_name,
+                    rate=frame_rate,  # param specific to cmx_3600 adapter
+                )
+            else:
+                otio.adapters.write_to_file(timeline, file_path, adapter_name=adapter_name)
+
+    def read_timeline_from_file(self, file_path, adapter_name=None, frame_rate=24):
+        """
+        Read and return a timeline from a file.
+
+        :param str file_path: Full path to the file to read.
+        :param str adapter_name: Optional otio adapter name, e.g. cmx_3600.
+        :param float frame_rate: Optional frame rate to use when reading the file.
+        :returns: A :class:`otio.schema.Timeline` instance.
+        """
+        _, ext = os.path.splitext(file_path)
+        if (ext and ext.lower() == ".edl") or adapter_name == "cmx_3600":
+            # rate param is specific to cmx_3600 adapter
+            timeline = otio.adapters.read_from_file(
+                file_path, adapter_name=adapter_name, rate=frame_rate
+            )
+        else:
+            timeline = otio.adapters.read_from_file(
+                file_path, adapter_name=adapter_name
+            )
+        return timeline
+
+    def write_to_sg(
+        self,
+        file_path,
+        entity_type,
+        entity_id,
+        adapter_name=None,
+        frame_rate=24,
+        settings=None,
+        movie=None,
+    ):
+        """
+        Write an input file to SG as a Cut.
+
+        The input file can be any format supported by OTIO.
+        If no adapter is provided, the default adapter for the file extension is used.
+
+        :param str file_path: Full path to the file to read.
+        :param str entity_type: A valid SG Entity type.
+        :param entity_id: A valid SG Entity id for the given Entity type.
+        :param str adapter_name: Optional otio adapter name, e.g. cmx_3600.
+        :param float frame_rate: Optional frame rate to use when reading the file.
+        :param str settings: Optional settings file path to use.
+        :param str movie: Optional movie file path to use with the Cut.
+        """
+        url = get_write_url(
+            sg_site_url=self._sg.base_url,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            session_token=self._sg_session_token
+        )
+        timeline = self.read_timeline_from_file(file_path, adapter_name, frame_rate)
+        if not timeline.video_tracks():
+            raise ValueError("The input file does not contain any video tracks.")
+        if settings:
+            SGSettings.from_file(settings)
+        if movie:
+            if not os.path.isfile(movie):
+                raise ValueError("%s does not exist" % movie)
+        if SGSettings().create_missing_versions and movie:
+            media_cutter = MediaCutter(
+                timeline,
+                movie,
+            )
+            media_cutter.cut_media_for_clips()
+
+        otio.adapters.write_to_file(
+            timeline,
+            url,
+            adapter_name="ShotGrid",
+            input_media=movie,
+            input_file=file_path,
+        )
+        logger.info("File %s successfully written to %s" % (file_path, url))
+
+    def compare_to_sg(self, file_path, sg_cut_id, adapter_name=None, frame_rate=24, write=False):
+        """
+        Compare an input file to a SG Cut.
+
+        :param str file_path: Full path to the file to read.
+        :param sg_cut_id: A valid SG Cut id.
+        :param str adapter_name: Optional otio adapter name, e.g. cmx_3600.
+        :param float frame_rate: Optional frame rate to use when reading the file.
+        :param bool write: If ``True`` do something...
+        """
+        timeline = self.read_timeline_from_file(file_path, adapter_name, frame_rate)
+        if not timeline.video_tracks():
+            raise ValueError("The input file does not contain any video tracks.")
+        new_track = timeline.video_tracks()[0]
+        url = get_read_url(
+            sg_site_url=self._sg.base_url,
+            cut_id=sg_cut_id,
+            session_token=self._sg_session_token
+        )
+        old_timeline = otio.adapters.read_from_file(
+            url,
+            adapter_name="ShotGrid",
+        )
+        if not old_timeline.video_tracks():
+            raise ValueError("The SG Cut does not contain any video tracks.")
+        sg_track = old_timeline.video_tracks()[0]
+        metadata = sg_track.metadata.to_dict()
+        diff = SGTrackDiff(
+            self._sg,
+            metadata["sg"]["project"],
+            new_track=new_track,
+            old_track=sg_track
+        )
+        old_cut_url = "%s/detail/Cut/%s" % (self._sg.base_url, sg_cut_id)
+        title, report = diff.get_report(
+            "%s" % os.path.basename(file_path),
+            sg_links=[old_cut_url]
+        )
+        logger.info(title)
+        logger.info(
+            report,
+        )
+        if write:
+            sg_entity = diff.sg_link
+            if not sg_entity:
+                raise ValueError("Can't update a Cut without a SG link.")
+            logger.info(
+                "Writing Cut %s to SG for %s %s..." % (
+                    new_track.name, sg_entity["type"], sg_entity["id"]
+                )
+            )
+            write_url = get_write_url(
+                sg_site_url=self._sg.base_url,
+                entity_type=sg_entity["type"],
+                entity_id=sg_entity["id"],
+                session_token=self._sg_session_token
+            )
+
+            otio.adapters.write_to_file(
+                new_track,
+                write_url,
+                adapter_name="ShotGrid",
+                previous_track=sg_track,
+                input_file=file_path,
+            )

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -394,6 +394,7 @@ class SGTrackDiff(object):
                     raise ValueError(
                         "Invalid clip %s not linked to a SG CutItem" % clip.name
                     )
+                sg_cut_item = sg_cut_item.to_dict()
                 sg_shot = sg_cut_item.get("shot")
                 if sg_shot:
                     shot_id = sg_shot.get("id")
@@ -1044,6 +1045,7 @@ class SGTrackDiff(object):
         new_track = self._new_track
         sg_cut = new_track.metadata.get("sg")
         if sg_cut:
+            sg_cut = sg_cut.to_dict()
             if sg_cut["type"] != "Cut":
                 raise ValueError(
                     "Invalid track %s not linked to a SG Cut" % new_track.name
@@ -1060,6 +1062,7 @@ class SGTrackDiff(object):
                 raise ValueError(
                     "Invalid track %s not linked to a SG Cut" % self._old_track.name
                 )
+            sg_cut = sg_cut.to_dict()
             # We don't support comparing Cuts from different SG Projects
             if sg_cut["project"]["id"] != self._sg_project["id"]:
                 raise ValueError(

--- a/tests/python/mock_grid.py
+++ b/tests/python/mock_grid.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the SG Otio project
 
-
+import json
 import shotgun_api3
 from shotgun_api3.lib import mockgun
 
@@ -10,6 +10,24 @@ class MockGrid(mockgun.Shotgun):
     """
     Override Mockgun base implementation to make it more SG compliant.
     """
+
+    def find(self, *args, **kwargs):
+        """
+        Mockgun find method.
+
+        Override base method so we can validate that arguments
+        are JSON serializable.
+
+        .. note:: Mockgun.find_one calls Mockgun.find so we only
+                  need to check arguments for the latter.
+        """
+        for arg in args:
+            if arg is not None:
+                json.dumps(arg)
+        for arg in kwargs.values():
+            if arg is not None:
+                json.dumps(arg)
+        return super(MockGrid, self).find(*args, **kwargs)
 
     def update(self, entity_type, entity_id, data):
         """

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the SG Otio project
+
+import logging
+import os
+import tempfile
+
+import shotgun_api3
+
+from .python.sg_test import SGBaseTest
+
+import opentimelineio as otio
+
+from sg_otio.command import SGOtioCommand
+from sg_otio.sg_settings import SGSettings
+from sg_otio.utils import get_write_url
+
+
+try:
+    # Python 3.3 forward includes the mock module
+    from unittest import mock
+except ImportError:
+    import mock
+
+logger = logging.getLogger(__name__)
+
+
+class TestCommand(SGBaseTest):
+    """
+    Test related to computing differences between two Cuts
+    """
+    def setUp(self):
+        """
+        Called before each test.
+        """
+        super(TestCommand, self).setUp()
+        self._sg_entities_to_delete = []
+        sg_settings = SGSettings()
+        sg_settings.reset_to_defaults()
+
+        self.mock_sequence = {
+            "project": self.mock_project,
+            "type": "Sequence",
+            "code": "SEQ01",
+            "id": 2,
+            "sg_cut_order": 2
+        }
+        self.add_to_sg_mock_db(self.mock_sequence)
+        self._SG_SEQ_URL = get_write_url(
+            self.mock_sg.base_url,
+            "Sequence",
+            self.mock_sequence["id"],
+            self._SESSION_TOKEN
+        )
+
+    def _add_sg_cut_data(self):
+        """
+        """
+        # SG is case insensitive but mockun is case sensitive so better to
+        # keep everything lower case.
+        self.sg_sequences = [{
+            "code": "seq_6666",
+            "project": self.mock_project,
+            "type": "Sequence",
+            "id": 6666,
+        }, {
+            "code": "seq_6667",
+            "project": self.mock_project,
+            "type": "Sequence",
+            "id": 6667,
+        }]
+        self.add_to_sg_mock_db(self.sg_sequences)
+        self._sg_entities_to_delete.extend(self.sg_sequences)
+        self.sg_shots = [{
+            "code": "shot_6666",
+            "project": self.mock_project,
+            "type": "Shot",
+            "sg_sequence": self.sg_sequences[0],
+            "id": 6666,
+            "sg_status_list": None,
+        }, {
+            "code": "shot_6667",
+            "project": self.mock_project,
+            "type": "Shot",
+            "sg_sequence": self.sg_sequences[0],
+            "id": 6667,
+            "sg_status_list": None,
+        }, {
+            "code": "shot_6668",
+            "project": self.mock_project,
+            "type": "Shot",
+            "sg_sequence": self.sg_sequences[0],
+            "id": 6668,
+            "sg_status_list": None,
+        }, {
+            "code": "shot_6669",
+            "project": self.mock_project,
+            "type": "Shot",
+            "sg_sequence": self.sg_sequences[0],
+            "id": 6669,
+            "sg_status_list": None,
+        }]
+        self.add_to_sg_mock_db(self.sg_shots)
+        self._sg_entities_to_delete.extend(self.sg_shots)
+        self.sg_cuts = [{
+            "code": "cut_6666",
+            "project": self.mock_project,
+            "type": "Cut",
+            "entity": self.sg_sequences[0],
+            "id": 6666,
+            "fps": 24.0,
+            "revision_number": 1,
+        }]
+        self.add_to_sg_mock_db(self.sg_cuts)
+        self._sg_entities_to_delete.extend(self.sg_cuts)
+        self.sg_cut_items = [{
+            "timecode_cut_item_out_text": "01:00:08:00",
+            "cut": self.sg_cuts[0],
+            "shot": self.sg_shots[0],
+            "cut_item_duration": 192,
+            "cut_item_in": 1008,
+            "cut_order": 1,
+            "timecode_cut_item_in_text": "01:00:00:00",
+            "version": None,
+            "cut_item_out": 1199,
+            "type": "CutItem",
+            "id": 54,
+            "code": "Item 54",
+            "timecode_edit_in_text": "07:00:00:00",
+            "timecode_edit_out_text": "07:00:08:00",
+        }, {
+            "timecode_cut_item_out_text": "00:00:05:00",
+            "cut": self.sg_cuts[0],
+            "shot": self.sg_shots[1],
+            "cut_item_duration": 111,
+            "cut_item_in": 1008,
+            "cut_order": 2,
+            "timecode_cut_item_in_text": "00:00:00:09",
+            "version": None,
+            "cut_item_out": 1118,
+            "type": "CutItem",
+            "id": 53,
+            "code": "Item 53",
+            "timecode_edit_in_text": "07:00:08:00",
+            "timecode_edit_out_text": "07:00:12:15",
+        }, {
+            "timecode_cut_item_out_text": "00:00:06:10",
+            "cut": self.sg_cuts[0],
+            "shot": self.sg_shots[2],
+            "cut_item_duration": 145,
+            "cut_item_in": 1008,
+            "cut_order": 3,
+            "timecode_cut_item_in_text": "00:00:00:09",
+            "version": None,
+            "cut_item_out": 1152,
+            "type": "CutItem",
+            "id": 52,
+            "code": "Item 52",
+            "timecode_edit_in_text": "07:00:12:15",
+            "timecode_edit_out_text": "07:00:18:16",
+        }, {
+            "timecode_cut_item_out_text": "00:00:07:16",
+            "cut": self.sg_cuts[0],
+            "shot": self.sg_shots[3],
+            "cut_item_duration": 175,
+            "cut_item_in": 1008,
+            "cut_order": 4,
+            "timecode_cut_item_in_text": "00:00:00:09",
+            "version": None,
+            "cut_item_out": 1182,
+            "type": "CutItem",
+            "id": 58,
+            "code": "Item 58",
+            "timecode_edit_in_text": "07:00:18:16",
+            "timecode_edit_out_text": "07:00:25:23",
+        }]
+        self.add_to_sg_mock_db(self.sg_cut_items)
+        self._sg_entities_to_delete.extend(self.sg_cut_items)
+
+    @staticmethod
+    def _mock_compute_clip_shot_name(clip):
+        """
+        Override compute clip shot name to get a unique shot name per clip.
+        """
+        return "shot_%d" % (6665 + list(clip.parent().each_clip()).index(clip) + 1)
+
+    def tearDown(self):
+        """
+        Called inconditionally after each test.
+        """
+        super(TestCommand, self).tearDown()
+        for sg_entity in self._sg_entities_to_delete:
+            logger.debug("Deleting %s %s" % (sg_entity["type"], sg_entity["id"]))
+            self.mock_sg.delete(sg_entity["type"], sg_entity["id"])
+        self._sg_entities_to_delete = []
+
+    def test_read_command(self):
+        """
+        Test the read command
+        """
+        self._add_sg_cut_data()
+        command = SGOtioCommand(self.mock_sg)
+        with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
+            with mock.patch("sg_otio.track_diff.compute_clip_shot_name", wraps=self._mock_compute_clip_shot_name):
+                with mock.patch("sg_otio.cut_clip.compute_clip_shot_name", wraps=self._mock_compute_clip_shot_name):
+                    _, path = tempfile.mkstemp(suffix=".otio")
+                    # Check read command
+                    command.read_from_sg(
+                        sg_cut_id=self.sg_cuts[0]["id"],
+                        file_path=path,
+                    )
+                    timeline = otio.adapters.read_from_file(path)
+                    self.assertEqual(len(timeline.tracks), 1)
+                    track = timeline.tracks[0]
+                    self.assertIsNotNone(track.metadata.get("sg"))
+                    sg_data = track.metadata["sg"]
+                    self.assertEqual(sg_data["type"], "Cut")
+                    self.assertEqual(sg_data["id"], self.sg_cuts[0]["id"])
+                    self.assertEqual(len(track), len(self.sg_cut_items))
+                    for i, clip in enumerate(track.each_clip()):
+                        # Just check basic stuff
+                        self.assertEqual(clip.name, self.sg_cut_items[i]["code"])
+                        self.assertEqual(
+                            clip.source_range.duration,
+                            otio.opentime.RationalTime(
+                                self.sg_cut_items[i]["cut_item_duration"],
+                                24,
+                            )
+                        )
+                    # Check compare command
+                    command.compare_to_sg(file_path=path, sg_cut_id=self.sg_cuts[0]["id"], write=True)
+                    new_cut = self.mock_sg.find_one(
+                        "Cut",
+                        [["id", "greater_than", self.sg_cuts[0]["id"]]],
+                    )
+                    self.assertTrue(new_cut)
+                    self._sg_entities_to_delete.append(new_cut)
+                    _, new_path = tempfile.mkstemp(suffix=".otio")
+                    command.read_from_sg(
+                        sg_cut_id=new_cut["id"],
+                        file_path=new_path,
+                    )
+                    new_timeline = otio.adapters.read_from_file(new_path)
+                    self.assertEqual(len(new_timeline.tracks), 1)
+                    new_track = new_timeline.tracks[0]
+                    self.assertIsNotNone(new_track.metadata.get("sg"))
+                    sg_data = new_track.metadata["sg"]
+                    self.assertEqual(sg_data["type"], "Cut")
+                    self.assertEqual(sg_data["id"], new_cut["id"])
+                    self.assertEqual(len(new_track), len(self.sg_cut_items))
+                    for i, clip in enumerate(new_track.each_clip()):
+                        # Just check basic stuff
+                        self.assertEqual(clip.name, self.sg_cut_items[i]["code"])
+                        self.assertEqual(
+                            clip.source_range.duration,
+                            otio.opentime.RationalTime(
+                                self.sg_cut_items[i]["cut_item_duration"],
+                                24,
+                            )
+                        )
+                    # Check write command
+                    command.write_to_sg(new_path, self.sg_sequences[0]["type"], self.sg_sequences[0]["id"])
+                    new_cut2 = self.mock_sg.find_one(
+                        "Cut",
+                        [["id", "greater_than", new_cut["id"]]],
+                    )
+                    self.assertTrue(new_cut2)
+                    self._sg_entities_to_delete.append(new_cut2)
+                    command.read_from_sg(
+                        sg_cut_id=new_cut["id"],
+                        file_path=new_path,
+                    )
+                    new_timeline = otio.adapters.read_from_file(new_path)
+                    self.assertEqual(len(new_timeline.tracks), 1)
+                    new_track = new_timeline.tracks[0]
+                    self.assertIsNotNone(new_track.metadata.get("sg"))
+                    sg_data = new_track.metadata["sg"]
+                    self.assertEqual(sg_data["type"], "Cut")
+                    self.assertEqual(sg_data["id"], new_cut["id"])
+                    self.assertEqual(len(new_track), len(self.sg_cut_items))
+                    for i, clip in enumerate(new_track.each_clip()):
+                        # Just check basic stuff
+                        self.assertEqual(clip.name, self.sg_cut_items[i]["code"])
+                        self.assertEqual(
+                            clip.source_range.duration,
+                            otio.opentime.RationalTime(
+                                self.sg_cut_items[i]["cut_item_duration"],
+                                24,
+                            )
+                        )
+            os.remove(path)
+            os.remove(new_path)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -56,7 +56,7 @@ class TestCommand(SGBaseTest):
     def _add_sg_cut_data(self):
         """
         """
-        # SG is case insensitive but mockun is case sensitive so better to
+        # SG is case insensitive but mockgun is case sensitive so better to
         # keep everything lower case.
         self.sg_sequences = [{
             "code": "seq_6666",


### PR DESCRIPTION
Changed MockGrid to fail on non JSON serializable requests. 
Added `to_dict` method similar to the one being in code review in opentimelineio. 
Call `to_dict` where needed.
Added SGOtioCommand and moved existing commands to it so it could be covered with unit test.
Added basic tests for SGOtioCommand