### PR TITLE
13244 csv report improvements

### DIFF
--- a/bin/sg-otio.py
+++ b/bin/sg-otio.py
@@ -106,6 +106,12 @@ def run():
         default=False,
         help="If true, update SG with values from the new Cut."
     )
+    compare_parser.add_argument(
+        "--report", "-rp",
+        required=False,
+        help="If set, write a report with changes. "
+             "Text or CSV files are generated, based on the file extension."
+    )
 
     args = parser.parse_args()
 
@@ -149,6 +155,7 @@ def run():
             adapter_name=args.adapter,
             frame_rate=args.frame_rate,
             write=args.write,
+            report_path=args.report,
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         ],
     },
     install_requires=[
-        "OpenTimelineIO == 0.12.1",
+        "OpenTimelineIO == 0.15.0",
         "shotgun-api3 >= 3.3.3",
         "pathlib2; python_version < '3.4'",
         "futures; python_version < '3.2'",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         ],
     },
     install_requires=[
-        "OpenTimelineIO >= 0.12.0",
+        "OpenTimelineIO == 0.12.1",
         "shotgun-api3 >= 3.3.3",
         "pathlib2; python_version < '3.4'",
         "futures; python_version < '3.2'",

--- a/sg_otio/command.py
+++ b/sg_otio/command.py
@@ -150,7 +150,15 @@ class SGOtioCommand(object):
         )
         logger.info("File %s successfully written to %s" % (file_path, url))
 
-    def compare_to_sg(self, file_path, sg_cut_id, adapter_name=None, frame_rate=24, write=False):
+    def compare_to_sg(
+        self,
+        file_path,
+        sg_cut_id,
+        adapter_name=None,
+        frame_rate=24,
+        write=False,
+        report_path=None,
+    ):
         """
         Compare an input file to a SG Cut.
 
@@ -158,7 +166,8 @@ class SGOtioCommand(object):
         :param sg_cut_id: A valid SG Cut id.
         :param str adapter_name: Optional otio adapter name, e.g. cmx_3600.
         :param float frame_rate: Optional frame rate to use when reading the file.
-        :param bool write: If ``True`` do something...
+        :param bool write: If ``True`` import the new Cut in SG.
+        :param str report_path: If set, write a CSV report to the given file.
         """
         timeline = self.read_timeline_from_file(file_path, adapter_name, frame_rate)
         if not timeline.video_tracks():
@@ -188,10 +197,21 @@ class SGOtioCommand(object):
             "%s" % os.path.basename(file_path),
             sg_links=[old_cut_url]
         )
-        logger.info(title)
-        logger.info(
-            report,
-        )
+        if report_path:
+            if os.path.splitext(report_path) == ".csv":
+                diff.write_csv_report(
+                    report_path, title, sg_links=[old_cut_url]
+                )
+            else:
+                with open(report_path, "w") as f:
+                    f.write(title)
+                    f.write(report)
+            logger.info("Report written to %s" % report_path)
+        else:
+            logger.info(title)
+            logger.info(
+                report,
+            )
         if write:
             sg_entity = diff.sg_link
             if not sg_entity:

--- a/sg_otio/command.py
+++ b/sg_otio/command.py
@@ -198,7 +198,7 @@ class SGOtioCommand(object):
             sg_links=[old_cut_url]
         )
         if report_path:
-            if os.path.splitext(report_path) == ".csv":
+            if os.path.splitext(report_path) in [".csv", ".CSV"]:
                 diff.write_csv_report(
                     report_path, title, sg_links=[old_cut_url]
                 )

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -824,9 +824,7 @@ class SGTrackDiff(object):
         with open(csv_path, "w", encoding="utf-8-sig") as csv_handle:
             csv_writer = csv.writer(csv_handle, lineterminator="\n")
             # Write some header information
-            data_row = ["Changes Report:", title] + [""] * 5
-            csv_writer.writerow(data_row)
-            data_row = ["(previous values in parenthesis if different)"] + [""] * 5
+            data_row = ["Changes Report:", title, "(previous values in parenthesis if different)"] + [""] * 4
             csv_writer.writerow(data_row)
             data_row = ["Report Date:", date.today().isoformat()] + [""] * 5
             csv_writer.writerow(data_row)

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -838,9 +838,9 @@ class SGTrackDiff(object):
                 data_row = ["Links:", " ".join(sg_links)] + [""] * 5
                 csv_writer.writerow(data_row)
                 csv_writer.writerow([""] * 7)
+            duration = self._new_track.duration()
             if self._old_track:
                 old_duration = self._old_track.duration()
-                duration = self._new_track.duration()
                 if old_duration != duration:
                     duration_frame = "%s (%s)" % (duration.to_frames(), old_duration.to_frames())
                     duration_tc = "%s (%s)" % (duration.to_timecode(), old_duration.to_timecode())

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -1304,28 +1304,41 @@ class TestCutDiff(SGBaseTest):
                         self.assertEqual(checks, 6)
                         in_edits_rows = True
                 else:
-                    # New cut items start after 4 first old cut items
-                    # and two first old items are omitted.
-                    item = self.sg_cut_items[edits_rows_count + 4]
-                    old_item = self.sg_cut_items[edits_rows_count + 2]
-                    self.assertEqual(row[0], "%s (%s)" % (
-                        item["cut_order"],
-                        old_item["cut_order"]
-                    ))
-                    self.assertEqual(row[1], _DIFF_TYPES.CUT_CHANGE.name)
-                    self.assertEqual(row[2], "%s" % item["shot"]["code"])
-                    self.assertEqual(row[3], "%s (%s)" % (item["cut_item_duration"], old_item["cut_item_duration"]))
-                    if item["cut_item_in"] != old_item["cut_item_in"]:
-                        self.assertEqual(row[4], "%s (%s)" % (item["cut_item_in"], old_item["cut_item_in"]))
+                    # We one line for cut change, then one line for
+                    # the omitted entry
+                    if edits_rows_count % 2:
+                        old_item = self.sg_cut_items[edits_rows_count // 2]
+                        self.assertEqual(row[0], "%s" % (
+                            old_item["cut_order"]
+                        ))
+                        self.assertEqual(row[1], _DIFF_TYPES.OMITTED.name)
+                        self.assertEqual(row[2], "%s" % old_item["shot"]["code"])
+                        self.assertEqual(row[3], "%s" % old_item["cut_item_duration"])
+                        self.assertEqual(row[4], "%s" % old_item["cut_item_in"])
+                        self.assertEqual(row[5], "%s" % old_item["cut_item_out"])
                     else:
-                        self.assertEqual(row[4], "%s" % item["cut_item_in"])
-                    if item["cut_item_out"] != old_item["cut_item_out"]:
-                        self.assertEqual(row[5], "%s (%s)" % (item["cut_item_out"], old_item["cut_item_out"]))
-                    else:
-                        self.assertEqual(row[5], "%s" % item["cut_item_out"])
+                        # New cut items start after 4 first old cut items
+                        # and two first old items are omitted.
+                        item = self.sg_cut_items[edits_rows_count // 2 + 4]
+                        old_item = self.sg_cut_items[edits_rows_count // 2 + 2]
+                        self.assertEqual(row[0], "%s (%s)" % (
+                            item["cut_order"],
+                            old_item["cut_order"]
+                        ))
+                        self.assertEqual(row[1], _DIFF_TYPES.CUT_CHANGE.name)
+                        self.assertEqual(row[2], "%s" % item["shot"]["code"])
+                        self.assertEqual(row[3], "%s (%s)" % (item["cut_item_duration"], old_item["cut_item_duration"]))
+                        if item["cut_item_in"] != old_item["cut_item_in"]:
+                            self.assertEqual(row[4], "%s (%s)" % (item["cut_item_in"], old_item["cut_item_in"]))
+                        else:
+                            self.assertEqual(row[4], "%s" % item["cut_item_in"])
+                        if item["cut_item_out"] != old_item["cut_item_out"]:
+                            self.assertEqual(row[5], "%s (%s)" % (item["cut_item_out"], old_item["cut_item_out"]))
+                        else:
+                            self.assertEqual(row[5], "%s" % item["cut_item_out"])
                     edits_rows_count += 1
                 logger.debug(row)
-            self.assertEqual(edits_rows_count, 2)
+            self.assertEqual(edits_rows_count, 4)  # 2 cut changes, 2 omitted edits
         os.remove(csv_path)
 
         SGSettings().shot_cut_fields_prefix = "myprecious"


### PR DESCRIPTION
Added the ability to generate a CSV or a text report from the `sg-otio` command.
Added missing omitted shots to CSV reports and made sure that rows were correctly sorted.
Added or changed tests for the new features.