### PR TITLE
For #13244, renamed diff type RESCAN to EXTENDED.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.
           token: ${{ secrets.GITHUB_TOKEN }}
+          architecture: "x64"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macos-12] # windows-latest when wheel is in place
+        os: [ubuntu-latest, macos-12] # windows-latest when wheel is in place, macos-latest is now arm64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
+        os: [ubuntu-latest, macos-12] # windows-latest when wheel is in place
 
     runs-on: ${{ matrix.os }}
 
@@ -45,7 +45,6 @@ jobs:
           # Not strictly necessary, but it may prevent rate limit
           # errors especially on GitHub-hosted macos machines.
           token: ${{ secrets.GITHUB_TOKEN }}
-          architecture: "x64"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -161,7 +161,7 @@ _DIFF_TYPES = enum.Enum(
         "NEW": 0,              # A new Shot will be created
         "OMITTED": 1,          # The Shot is not part of the cut anymore
         "REINSTATED": 2,       # The Shot is back in the cut
-        "RESCAN": 3,           # A rescan will be needed with the new in / out points
+        "EXTENDED": 3,         # New in and/or out points are outside previous range
         "CUT_CHANGE": 4,       # Some values changed, but don't fall in previous categories
         "NO_CHANGE": 5,        # Values are identical to previous ones
         "NO_LINK": 6,          # Related Shot name couldn't be found

--- a/sg_otio/cut_diff.py
+++ b/sg_otio/cut_diff.py
@@ -371,7 +371,7 @@ class SGCutDiff(SGCutClip):
 
         :returns: ``True`` if a rescan is needed, ``False`` otherwise
         """
-        return self._diff_type == _DIFF_TYPES.RESCAN
+        return self._diff_type == _DIFF_TYPES.EXTENDED
 
     @property
     def repeated(self):
@@ -509,14 +509,14 @@ class SGCutDiff(SGCutClip):
             and self.head_duration is not None
             and self.head_duration.to_frames() < 0
         ):
-            self._diff_type = _DIFF_TYPES.RESCAN
+            self._diff_type = _DIFF_TYPES.EXTENDED
 
         if (
             self.sg_shot_tail_out is not None  # Report rescan only if value is set on the Shot
             and self.tail_duration is not None
             and self.tail_duration.to_frames() < 0
         ):
-            self._diff_type = _DIFF_TYPES.RESCAN
+            self._diff_type = _DIFF_TYPES.EXTENDED
 
         # We use cut in and cut out values which accurately report changes since
         # they are not based on Shot values.
@@ -525,7 +525,7 @@ class SGCutDiff(SGCutClip):
             and self.cut_in is not None
             and self.old_cut_in != self.cut_in
         ):
-            if self._diff_type != _DIFF_TYPES.RESCAN:
+            if self._diff_type != _DIFF_TYPES.EXTENDED:
                 self._diff_type = _DIFF_TYPES.CUT_CHANGE
             diff = (self.cut_in - self.old_cut_in).to_frames()
             if diff > 0:
@@ -538,7 +538,7 @@ class SGCutDiff(SGCutClip):
             and self.cut_out is not None
             and self.old_cut_out != self.cut_out
         ):
-            if self._diff_type != _DIFF_TYPES.RESCAN:
+            if self._diff_type != _DIFF_TYPES.EXTENDED:
                 self._diff_type = _DIFF_TYPES.CUT_CHANGE
             diff = (self.cut_out - self.old_cut_out).to_frames()
             if diff > 0:

--- a/sg_otio/track_diff.py
+++ b/sg_otio/track_diff.py
@@ -28,7 +28,7 @@ _PER_SHOT_TYPE_COUNTS = [
     _DIFF_TYPES.NEW,
     _DIFF_TYPES.OMITTED,
     _DIFF_TYPES.REINSTATED,
-    _DIFF_TYPES.RESCAN
+    _DIFF_TYPES.EXTENDED,
 ]
 
 
@@ -242,14 +242,14 @@ class SGCutDiffGroup(ClipGroup):
             # - A Shot is NEW if any of its items is NEW (should be all of them)
             # - A Shot is REINSTATED if at least one of its items is REINSTATED (should
             #       be all of them)
-            # - A Shot needs RESCAN if any of its items need RESCAN
+            # - A Shot needs RESCAN if any of its items is EXTENDED
             cut_diff_type = cut_diff.diff_type
             if cut_diff_type in [
                 _DIFF_TYPES.NO_LINK,
                 _DIFF_TYPES.NEW,
                 _DIFF_TYPES.REINSTATED,
                 _DIFF_TYPES.OMITTED,
-                _DIFF_TYPES.RESCAN
+                _DIFF_TYPES.EXTENDED,
             ]:
                 shot_diff_type = cut_diff_type
                 # Can't be changed by another entry, no need to loop further
@@ -861,7 +861,7 @@ class SGTrackDiff(object):
             csv_writer.writerow(data_row)
             count = (
                 self.count_for_type(_DIFF_TYPES.NEW) + self.count_for_type(_DIFF_TYPES.CUT_CHANGE)
-                + self.count_for_type(_DIFF_TYPES.REINSTATED) + self.count_for_type(_DIFF_TYPES.RESCAN)
+                + self.count_for_type(_DIFF_TYPES.REINSTATED) + self.count_for_type(_DIFF_TYPES.EXTENDED)
                 + self.count_for_type(_DIFF_TYPES.NO_CHANGE)
             )
             total_count = "%d" % count
@@ -989,7 +989,7 @@ class SGTrackDiff(object):
             "%s - %s" % (
                 diff.name, ", ".join(diff.reasons)
             ) for diff in sorted(
-                self.diffs_for_type(_DIFF_TYPES.RESCAN),
+                self.diffs_for_type(_DIFF_TYPES.EXTENDED),
                 key=lambda x: x.index
             )
         ]
@@ -1032,7 +1032,7 @@ class SGTrackDiff(object):
             ]),
             self.count_for_type(_DIFF_TYPES.CUT_CHANGE),
             "\n".join(cut_changes_details),
-            self.count_for_type(_DIFF_TYPES.RESCAN),
+            self.count_for_type(_DIFF_TYPES.EXTENDED),
             "\n".join(rescan_details),
         )
         return subject, body
@@ -1072,8 +1072,8 @@ class SGTrackDiff(object):
             self.diffs_for_type(_DIFF_TYPES.CUT_CHANGE),
             key=lambda x: x.index
         )
-        diff_groups[_DIFF_TYPES.RESCAN] = sorted(
-            self.diffs_for_type(_DIFF_TYPES.RESCAN),
+        diff_groups[_DIFF_TYPES.EXTENDED] = sorted(
+            self.diffs_for_type(_DIFF_TYPES.EXTENDED),
             key=lambda x: x.index
         )
         diff_groups[_DIFF_TYPES.NO_LINK] = sorted(

--- a/tests/test_cut_diff.py
+++ b/tests/test_cut_diff.py
@@ -1012,7 +1012,7 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
         self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
         self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
-        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
+        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.EXTENDED)
 
         # Same cut in, cut out after registered handles.
         clip.source_range = TimeRange(
@@ -1029,7 +1029,7 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
         self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
         self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
-        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
+        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.EXTENDED)
 
         # Both cut in and cut out out of handle margins.
         clip.source_range = TimeRange(
@@ -1049,7 +1049,7 @@ class TestCutDiff(SGBaseTest):
         self.assertEqual(cut_diff.old_cut_in.to_frames(), 1009)
         self.assertEqual(cut_diff.old_head_duration.to_frames(), 8)
         self.assertEqual(cut_diff.old_tail_duration.to_frames(), 8)
-        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.RESCAN)
+        self.assertEqual(cut_diff.diff_type, _DIFF_TYPES.EXTENDED)
 
     def test_report(self):
         """


### PR DESCRIPTION
Renamed the RESCAN constant to EXTENDED, but kept some rescan related methods around.

_Note: lastest macOS is amr64 and installing ffmpeg fails for it_