### PR TITLE
For #14202, working_duration fix.

### DIFF
--- a/sg_otio/clip_group.py
+++ b/sg_otio/clip_group.py
@@ -435,7 +435,7 @@ class ClipGroup(object):
 
         :returns: A :class:`otio.opentime.RationalTime` instance.
         """
-        return self.tail_out - self.head_in
+        return self.tail_out - self.head_in + RationalTime(1, self._frame_rate)
 
     @property
     def sg_shot_is_omitted(self):

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -578,7 +578,7 @@ class SGCutClip(object):
 
         :returns: A :class:`RationalTime` instance.
         """
-        return self.tail_out - self.head_in  + RationalTime(1, self._frame_rate)
+        return self.tail_out - self.head_in + RationalTime(1, self._frame_rate)
 
     @property
     def transition_before(self):

--- a/sg_otio/cut_clip.py
+++ b/sg_otio/cut_clip.py
@@ -578,7 +578,7 @@ class SGCutClip(object):
 
         :returns: A :class:`RationalTime` instance.
         """
-        return self.tail_out - self.head_in
+        return self.tail_out - self.head_in  + RationalTime(1, self._frame_rate)
 
     @property
     def transition_before(self):

--- a/tests/test_clip_group.py
+++ b/tests/test_clip_group.py
@@ -145,7 +145,7 @@ class TestClipGroup(unittest.TestCase):
             self.assertTrue(not shot.has_effects)
             self.assertTrue(not shot.has_retime)
             self.assertEqual(shot.duration.to_frames(), 10 * 24)
-            self.assertEqual(shot.working_duration.to_frames(), head_duration + 10 * 24 + tail_duration - 1)
+            self.assertEqual(shot.working_duration.to_frames(), head_duration + 10 * 24 + tail_duration)
             clips = list(shot.clips)
             self.assertEqual(len(clips), 2)
             self.assertEqual(clips[0].cut_in.to_frames(), head_in + head_duration + 24)

--- a/tests/test_cut_clip.py
+++ b/tests/test_cut_clip.py
@@ -184,6 +184,7 @@ class TestCutClip(unittest.TestCase):
         # There's a retime, so the clip is actually 2 * 0.5 seconds long.
         self.assertEqual(clip_1.duration().to_frames(), 24)
         self.assertEqual(clip_1.visible_duration.to_frames(), 48)
+        self.assertEqual(clip_1.working_duration.to_frames(), 10 + 48 + 20)
         self.assertEqual(clip_1.source_in.to_timecode(), "01:00:00:00")
         self.assertEqual(clip_1.source_out.to_timecode(), "01:00:02:00")
         self.assertEqual(clip_1.cut_in.to_frames(), sg_settings.default_head_in + sg_settings.default_head_duration)
@@ -204,6 +205,7 @@ class TestCutClip(unittest.TestCase):
         clip_2 = clips[1]
         self.assertEqual(clip_2.duration().to_frames(), 24)
         self.assertEqual(clip_2.visible_duration.to_frames(), 24)
+        self.assertEqual(clip_2.working_duration.to_frames(), 10 + 24 + 20)
         self.assertEqual(clip_2.source_in.to_timecode(), "00:00:00:00")
         self.assertEqual(clip_2.source_out.to_timecode(), "00:00:01:00")
         self.assertEqual(clip_2.cut_in.to_frames(), sg_settings.default_head_in + sg_settings.default_head_duration)
@@ -265,6 +267,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip_1.duration().to_frames(), 24)
         # The visible duration takes into account the whole duration of the transition
         self.assertEqual(clip_1.visible_duration.to_frames(), 48)
+        self.assertEqual(clip_1.working_duration.to_frames(), 10 + 48 + 20)
         # All out values take into account the transition time
         self.assertEqual(clip_1.source_in.to_timecode(), "01:00:00:00")
         self.assertEqual(clip_1.source_out.to_timecode(), "01:00:02:00")
@@ -283,6 +286,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(clip_2.duration().to_frames(), 24)
         # The visible duration takes into account the whole duration of the transition
         self.assertEqual(clip_2.visible_duration.to_frames(), 24)
+        self.assertEqual(clip_2.working_duration.to_frames(), 10 + 24 + 20)
         self.assertEqual(clip_2.source_in.to_timecode(), "01:00:01:00")
         self.assertEqual(clip_2.source_out.to_timecode(), "01:00:02:00")
         self.assertEqual(clip_2.cut_in.to_frames(), sg_settings.default_head_in + sg_settings.default_head_duration)
@@ -312,6 +316,7 @@ class TestCutClip(unittest.TestCase):
         self.assertEqual(cut_clip.duration().to_frames(), 120)
         # The visible duration takes into account the whole duration of the transition
         self.assertEqual(cut_clip.visible_duration.to_frames(), 150)
+        self.assertEqual(cut_clip.working_duration.to_frames(), 8 + 150 + 8)  # Default handles are 8 frames
         self.assertTrue(cut_clip.has_effects)
         self.assertEqual(cut_clip.effects_str, "Before: SMPTE_Dissolve (0 frames)\nAfter: SMPTE_Dissolve (30 frames)")
 


### PR DESCRIPTION
One frame was missing in computed value.

Please double check why [this](https://github.com/GPLgithub/tk-multi-importcut/blob/809368401ba5df9a632baf1bbfe4322aa148b1c4/python/tk_multi_importcut/edl_cut.py#L1307) was not kept when moving to sg-otio.