### PR TITLE
For #14005, cut change for no handles.

### DIFF
--- a/sg_otio/constants.py
+++ b/sg_otio/constants.py
@@ -161,7 +161,7 @@ _DIFF_TYPES = enum.Enum(
         "NEW": 0,              # A new Shot will be created
         "OMITTED": 1,          # The Shot is not part of the cut anymore
         "REINSTATED": 2,       # The Shot is back in the cut
-        "EXTENDED": 3,         # New in and/or out points are outside previous range
+        "EXTENDED": 3,         # When using handles, new in and/or out points are outside previous head in/tail out range
         "CUT_CHANGE": 4,       # Some values changed, but don't fall in previous categories
         "NO_CHANGE": 5,        # Values are identical to previous ones
         "NO_LINK": 6,          # Related Shot name couldn't be found


### PR DESCRIPTION
Changed the logic to not report EXTENDED anymore if handles are not in use (default value set to 0 in settings).
Adapted tests for the new logic.