### PR TITLE
For #15062: Fixed effects added to  key in the payload

### DIFF
--- a/sg_otio/sg_cut_track_writer.py
+++ b/sg_otio/sg_cut_track_writer.py
@@ -904,7 +904,6 @@ class SGCutTrackWriter(object):
             sfg.cut_duration: clip_group.duration.to_frames(),
             sfg.cut_order: clip_group.index,
         }
-
         if sg_user and not clip_group.sg_shot:  # Only settable on create
             shot_payload["created_by"] = sg_user
             shot_payload["updated_by"] = sg_user
@@ -919,8 +918,9 @@ class SGCutTrackWriter(object):
         if sfg.tail_duration:
             shot_payload[sfg.tail_duration] = clip_group.tail_duration.to_frames()
         # TODO: Add setting for flagging retimes and effects?
-        if True:
+        if sfg.has_effects:
             shot_payload[sfg.has_effects] = clip_group.has_effects
+        if sfg.has_retime:
             shot_payload[sfg.has_retime] = clip_group.has_retime
         if sfg.absolute_cut_order and sg_linked_entity.get(sfg.absolute_cut_order):
             entity_cut_order = sg_linked_entity[sfg.absolute_cut_order]

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -1051,7 +1051,6 @@ class ShotgridAdapterTest(SGBaseTest):
                 # Verify that `None` is not a key
                 self.assertNotIn(None, payload)
 
-
     def test_shot_status(self):
         """
         Test setting the Shot status from cut changes.


### PR DESCRIPTION
- fixed the problem by not letting `None` values affect the payload
- Added test that checks that retimes/effects are properly added when available.