### PR TITLE
For #15193, Shot re-use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     name: "sg-otio"
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-12] # windows-latest when wheel is in place, macos-latest is now arm64
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Allowed Shots to be matched against a target Entity, but also to fallback on Shots linked to other entities in the current Project.