### PR TITLE
For #15197, fix for when not updating Shots

### DIFF
--- a/sg_otio/adapters/shotgrid.py
+++ b/sg_otio/adapters/shotgrid.py
@@ -65,7 +65,7 @@ def read_from_file(filepath):
     return SGCutReader(sg).read(cut_id)
 
 
-def write_to_file(input_otio, filepath, input_media=None, previous_track=None, input_file=None):
+def write_to_file(input_otio, filepath, input_media=None, previous_track=None, input_file=None, update_shots=True):
     """
     Write the given timeline to SG.
 
@@ -87,6 +87,7 @@ def write_to_file(input_otio, filepath, input_media=None, previous_track=None, i
     :param str input_media: A path to a media file representing the video track, if any.
     :param previous_track: An optional :class:`otio.schema.Track` instance.
     :param str input_file: Optional input source file for the Cut.
+    :param bool update_shots: Whether existing Shots should be updated or not.
     :raises ValueError: For unsupported SG Entity types.
     """
     if not isinstance(input_otio, otio.schema.Timeline) and not isinstance(input_otio, otio.schema.Track):
@@ -115,6 +116,7 @@ def write_to_file(input_otio, filepath, input_media=None, previous_track=None, i
         description="Generated from sg-otio",
         input_media=input_media,
         previous_track=previous_track,
-        input_file=input_file
+        input_file=input_file,
+        update_shots=update_shots,
     )
     return

--- a/sg_otio/command.py
+++ b/sg_otio/command.py
@@ -105,6 +105,7 @@ class SGOtioCommand(object):
         frame_rate=24,
         settings=None,
         movie=None,
+        update_shots=True,
     ):
         """
         Write an input file to SG as a Cut.
@@ -119,6 +120,7 @@ class SGOtioCommand(object):
         :param float frame_rate: Optional frame rate to use when reading the file.
         :param str settings: Optional settings file path to use.
         :param str movie: Optional movie file path to use with the Cut.
+        :param bool update_shots: Whether existing Shots should be updated or not.
         """
         url = get_write_url(
             sg_site_url=self._sg.base_url,
@@ -147,6 +149,7 @@ class SGOtioCommand(object):
             adapter_name="ShotGrid",
             input_media=movie,
             input_file=file_path,
+            update_shots=update_shots,
         )
         logger.info("File %s successfully written to %s" % (file_path, url))
 

--- a/tests/test_shotgrid_adapter.py
+++ b/tests/test_shotgrid_adapter.py
@@ -1242,7 +1242,7 @@ class ShotgridAdapterTest(SGBaseTest):
             self.assertEqual(clip.metadata["sg"]["cut_item_in"], 1009)
             self.assertEqual(clip.metadata["sg"]["shot"]["code"], "test_write_shot_SHOT_001")
         # Do it again with update_shots enabled. Since everything is up to date
-        # Shots should be updated.
+        # Shots shouldn't be updated.
         with mock.patch.object(shotgun_api3, "Shotgun", return_value=self.mock_sg):
             otio.adapters.write_to_file(timeline, self._SG_SEQ_URL, "ShotGrid", update_shots=True)
 


### PR DESCRIPTION
Ensured the full list of Shots is always returned. 
Added the ability to run the adapter with update_shots set to `False`.
Added test for import without updating Shots.